### PR TITLE
#36 implemented global leaderbord endpoint/logic

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/UserController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/UserController.java
@@ -31,11 +31,15 @@ public class UserController {
 		this.userService = userService;
 	}
 
-	@GetMapping("/users")
+	@GetMapping("/users/leaderboard")
 	@ResponseStatus(HttpStatus.OK)
-	public List<UserGetDTO> getAllUsers() {
-		// fetch all users in the internal representation
-		List<User> users = userService.getUsers();
+	public List<UserGetDTO> getGlobalLeaderboard(@RequestHeader(value = "token", required = false)  String token) {
+		
+		//check for permission
+		userService.verifyToken(token);
+
+		// fetch all users in the internal representation and sort them by totalPoints
+		List<User> users = userService.getGlobalUsersLeaderboard();
 		List<UserGetDTO> userGetDTOs = new ArrayList<>();
 
 		// convert each user to the API representation

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/User.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/User.java
@@ -58,6 +58,9 @@ public class User implements Serializable {
 	@Column(nullable = false)
 	private Long totalPoints;
 
+	@Transient //@Transient means field is not persistent, it is simply defined and used to ad hoc rank players (no need to store in db)
+	private Integer rank;
+
 	public Long getId() {
 		return id;
 	}
@@ -145,4 +148,13 @@ public class User implements Serializable {
 	public void setTotalPoints(Long totalPoints) {
 		this.totalPoints = totalPoints;
 	}
+
+	public Integer getRank() {
+		return rank;
+	}
+
+	public void setRank(Integer rank) {
+		this.rank = rank;
+	}
+
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/UserRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/UserRepository.java
@@ -5,11 +5,13 @@ import org.springframework.stereotype.Repository;
 
 import ch.uzh.ifi.hase.soprafs26.entity.User;
 
+import java.util.List;
+
 @Repository("userRepository")
 public interface UserRepository extends JpaRepository<User, Long> {
 
-	
-
 	User findByUsername(String username);
 	User findByToken(String token);
+
+	List<User> findAllByOrderByTotalPointsDesc(); //JPA transforms it into SQL query: 'SELECT * FROM users ORDER BY totalPoints DESC;'
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/UserGetDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/UserGetDTO.java
@@ -1,13 +1,21 @@
 package ch.uzh.ifi.hase.soprafs26.rest.dto;
 
+import java.util.Date;
+
 import ch.uzh.ifi.hase.soprafs26.constant.UserStatus;
 
 public class UserGetDTO {
 
 	private Long id;
-
 	private String username;
 	private UserStatus status;
+	private String bio;
+    private Date creationDate;
+    private int winCount;
+    private double winRatePercentage;
+    private int totalGamesPlayed;
+    private long totalPoints;
+	private Integer rank;
 
 	public Long getId() {
 		return id;
@@ -31,5 +39,61 @@ public class UserGetDTO {
 
 	public void setStatus(UserStatus status) {
 		this.status = status;
+	}
+
+	public String getBio() {
+		return bio;
+	}
+
+	public void setBio(String bio) {
+		this.bio = bio;
+	}
+
+	public Date getCreationDate() {
+		return creationDate;
+	}
+
+	public void setCreationDate(Date creationDate) {
+		this.creationDate = creationDate;
+	}
+
+	public int getWinCount() {
+		return winCount;
+	}
+
+	public void setWinCount(int winCount) {
+		this.winCount = winCount;
+	}
+
+	public double getWinRatePercentage() {
+		return winRatePercentage;
+	}
+
+	public void setWinRatePercentage(double winRatePercentage) {
+		this.winRatePercentage = winRatePercentage;
+	}
+
+	public int getTotalGamesPlayed() {
+		return totalGamesPlayed;
+	}
+
+	public void setTotalGamesPlayed(int totalGamesPlayed) {
+		this.totalGamesPlayed = totalGamesPlayed;
+	}
+
+	public long getTotalPoints() {
+		return totalPoints;
+	}
+
+	public void setTotalPoints(long totalPoints) {
+		this.totalPoints = totalPoints;
+	}
+
+	public Integer getRank() {
+		return rank;
+	}
+
+	public void setRank(Integer rank) {
+		this.rank = rank;
 	}
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapper.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapper.java
@@ -37,6 +37,13 @@ public interface DTOMapper {
 	@Mapping(source = "id", target = "id")
 	@Mapping(source = "username", target = "username")
 	@Mapping(source = "status", target = "status")
+	@Mapping(source = "bio", target = "bio")
+	@Mapping(source = "creationDate", target = "creationDate")
+	@Mapping(source = "winCount", target = "winCount")
+	@Mapping(source = "winRatePercentage", target = "winRatePercentage")
+	@Mapping(source = "totalGamesPlayed", target = "totalGamesPlayed")
+	@Mapping(source = "totalPoints", target = "totalPoints")
+	@Mapping(source = "rank", target = "rank")
 	UserGetDTO convertEntityToUserGetDTO(User user);
 
 	@Mapping(source = "id", target = "id")

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/UserService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/UserService.java
@@ -34,8 +34,14 @@ public class UserService {
 		this.userRepository = userRepository;
 	}
 
-	public List<User> getUsers() {
-		return this.userRepository.findAll();
+	public List<User> getGlobalUsersLeaderboard() {
+
+		List<User> users = userRepository.findAllByOrderByTotalPointsDesc();
+
+		for (int i = 0; i < users.size(); i++) {
+			users.get(i).setRank(i + 1);
+		}
+		return users;
 	}
 
 	public User createUser(User newUser) {

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/UserControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/UserControllerTest.java
@@ -50,27 +50,64 @@ class UserControllerTest {
 	@MockitoBean
 	private UserService userService;
 
+	//Happy Test: /users/leaderboard; expect: 200
 	@Test
-	void givenUsers_whenGetUsers_thenReturnJsonArray() throws Exception {
+	void givenUsers_getGlobalUsersLeaderboard_thenReturnJsonArray() throws Exception {
 		// given
 		User user = new User();
+		user.setId(1L);
 		user.setUsername("firstname@lastname");
 		user.setStatus(UserStatus.OFFLINE);
+		user.setBio("testBio");
+		user.setWinCount(0);
+		user.setWinRatePercentage(0.0);
+		user.setTotalGamesPlayed(0);
+		user.setTotalPoints(0L);
+		user.setRank(1); //rank 1, only one user
+
+		Date date = new Date();
+		user.setCreationDate(date);
 
 		List<User> allUsers = Collections.singletonList(user);
 
 		// this mocks the UserService -> we define above what the userService should
 		// return when getUsers() is called
-		given(userService.getUsers()).willReturn(allUsers);
+		given(userService.getGlobalUsersLeaderboard()).willReturn(allUsers);
 
 		// when
-		MockHttpServletRequestBuilder getRequest = get("/users").contentType(MediaType.APPLICATION_JSON);
+		MockHttpServletRequestBuilder getRequest = get("/users/leaderboard").contentType(MediaType.APPLICATION_JSON);
 
 		// then
 		mockMvc.perform(getRequest).andExpect(status().isOk())
 				.andExpect(jsonPath("$", hasSize(1)))
+				.andExpect(jsonPath("$[0].id", is(user.getId().intValue())))
 				.andExpect(jsonPath("$[0].username", is(user.getUsername())))
-				.andExpect(jsonPath("$[0].status", is(user.getStatus().toString())));
+				.andExpect(jsonPath("$[0].status", is(user.getStatus().toString())))
+				.andExpect(jsonPath("$[0].creationDate").isNotEmpty())
+				.andExpect(jsonPath("$[0].bio", is(user.getBio())))
+				.andExpect(jsonPath("$[0].winCount", is(user.getWinCount())))
+				.andExpect(jsonPath("$[0].winRatePercentage", is(user.getWinRatePercentage())))
+				.andExpect(jsonPath("$[0].totalGamesPlayed", is(user.getTotalGamesPlayed())))
+				.andExpect(jsonPath("$[0].totalPoints", is(user.getTotalPoints().intValue())))
+				.andExpect(jsonPath("$[0].rank", is(user.getRank())));
+	}
+
+	//Unhappy Test: /users/leaderboard; expect: 401
+	@Test
+	void failedToGetGlobalUsersLeaderboard_userUnauthorized() throws Exception {
+		User user = new User();
+		user.setToken("invalidToken");
+
+		String errorReason = "Token is invalid";
+		Mockito.doThrow(new ResponseStatusException(HttpStatus.UNAUTHORIZED, errorReason))
+				.when(userService).verifyToken(Mockito.any());
+
+		MockHttpServletRequestBuilder getRequest = get("/users/leaderboard").contentType(MediaType.APPLICATION_JSON);
+
+		mockMvc.perform(getRequest)
+				.andExpect(status().isUnauthorized())
+				.andExpect(jsonPath("$.detail", is(errorReason)));
+
 	}
 
 	//Happy Test: /users/register; expect: 201

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/repository/UserRepositoryIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/repository/UserRepositoryIntegrationTest.java
@@ -11,6 +11,8 @@ import ch.uzh.ifi.hase.soprafs26.entity.User;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import java.util.List;
+
 @DataJpaTest
 class UserRepositoryIntegrationTest {
 
@@ -84,5 +86,51 @@ class UserRepositoryIntegrationTest {
 		assertEquals(found.getWinRatePercentage(), user.getWinRatePercentage());
 		assertEquals(found.getTotalGamesPlayed(), user.getTotalGamesPlayed());
 		assertEquals(found.getTotalPoints(), user.getTotalPoints());
+	}
+
+	@Test
+	void findAllByOrderByTotalPointsDesc_success() {
+		
+		// given: 3 users with some points
+		User user1 = new User();
+		user1.setTotalPoints(100L);
+		user1.setUsername("user1");
+		user1.setPassword("newPassword1");
+		user1.setStatus(UserStatus.ONLINE);
+		user1.setToken("validToken1");
+		user1.setWinCount(5);
+		user1.setWinRatePercentage(50.0);
+		user1.setTotalGamesPlayed(10);
+
+		User user2 = new User();
+		user2.setTotalPoints(5432L);
+		user2.setUsername("user2");
+		user2.setPassword("newPassword2");
+		user2.setStatus(UserStatus.ONLINE);
+		user2.setToken("validToken2");
+		user2.setWinCount(123);
+		user2.setWinRatePercentage(100.0);
+		user2.setTotalGamesPlayed(123);
+
+		User user3 = new User();
+		user3.setTotalPoints(50L);
+		user3.setUsername("user3");
+		user3.setPassword("newPassword3");
+		user3.setStatus(UserStatus.ONLINE);
+		user3.setToken("validToken3");
+		user3.setWinCount(2);
+		user3.setWinRatePercentage(50.0);
+		user3.setTotalGamesPlayed(4);
+
+		entityManager.persist(user1);
+		entityManager.persist(user2);
+		entityManager.persist(user3);
+		entityManager.flush();
+
+		List<User> users = userRepository.findAllByOrderByTotalPointsDesc();
+
+		assertEquals(5432L, users.get(0).getTotalPoints());
+    	assertEquals(100L, users.get(1).getTotalPoints());
+   		assertEquals(50L, users.get(2).getTotalPoints());
 	}
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapperTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapperTest.java
@@ -13,6 +13,7 @@ import ch.uzh.ifi.hase.soprafs26.rest.dto.UserGetDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.UserPostDTO;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Date;
@@ -37,13 +38,23 @@ class DTOMapperTest {
 		assertEquals(userPostDTO.getUsername(), user.getUsername());
 	}
 
+
 	@Test
 	void testGetUser_fromUser_toUserGetDTO_success() {
 		// create User
 		User user = new User();
+		user.setId(1L);
 		user.setUsername("firstname@lastname");
 		user.setStatus(UserStatus.OFFLINE);
-		user.setToken("1");
+		user.setBio("borbone is goated");
+		user.setWinCount(10);
+		user.setWinRatePercentage(100.0);
+		user.setTotalGamesPlayed(10);
+		user.setTotalPoints(1000L);
+		user.setRank(1);
+
+		Date date = new Date();
+		user.setCreationDate(date);
 
 		// MAP -> Create UserGetDTO
 		UserGetDTO userGetDTO = DTOMapper.INSTANCE.convertEntityToUserGetDTO(user);
@@ -52,6 +63,13 @@ class DTOMapperTest {
 		assertEquals(user.getId(), userGetDTO.getId());
 		assertEquals(user.getUsername(), userGetDTO.getUsername());
 		assertEquals(user.getStatus(), userGetDTO.getStatus());
+		assertEquals(user.getBio(), userGetDTO.getBio());
+		assertEquals(user.getWinCount(), userGetDTO.getWinCount());
+		assertEquals(user.getWinRatePercentage(), userGetDTO.getWinRatePercentage());
+		assertEquals(user.getTotalGamesPlayed(), userGetDTO.getTotalGamesPlayed());
+		assertEquals(user.getTotalPoints(), userGetDTO.getTotalPoints());
+		assertEquals(user.getRank(), userGetDTO.getRank());
+		assertNotNull(userGetDTO.getCreationDate());
 	}
 
 	@Test

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/UserServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/UserServiceTest.java
@@ -15,6 +15,7 @@ import ch.uzh.ifi.hase.soprafs26.repository.UserRepository;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Optional;
+import java.util.List;
 
 class UserServiceTest {
 
@@ -181,4 +182,39 @@ class UserServiceTest {
 		Mockito.verify(userRepository, Mockito.times(2)).save(user); // Verify that the user is saved two times (once for password change, once for status update)
 		Mockito.verify(userRepository, Mockito.times(2)).flush(); // Verify that flush is called two times to persist the changes
 	}
+
+	@Test
+	void getGlobalUsersLeaderboard_assignsRanksCorrectly() {
+		
+		// given
+		User user1 = new User();
+		user1.setTotalPoints(29L);
+
+		User user2 = new User();
+		user2.setTotalPoints(30L);
+
+		User user3 = new User();
+		user3.setTotalPoints(90L);
+
+		List<User> users = List.of(user1, user2, user3);
+		Mockito.when(userRepository.findAllByOrderByTotalPointsDesc()).thenReturn(users);
+
+		// when
+		List<User> result = userService.getGlobalUsersLeaderboard();
+
+		// then
+		assertEquals(1, result.get(0).getRank());
+		assertEquals(2, result.get(1).getRank());
+		assertEquals(3, result.get(2).getRank());
+	}
+
+	@Test
+	void getGlobalUsersLeaderboard_noUsers_returnsEmptyList() { // function does not break when no users stored
+
+		Mockito.when(userRepository.findAllByOrderByTotalPointsDesc()).thenReturn(List.of()); //return empty list
+		
+		List<User> users = userService.getGlobalUsersLeaderboard();
+		
+		assertTrue(users.isEmpty());
+}
 }


### PR DESCRIPTION
- implemented global leaderboard
- global leaderboard is basically the users dashboard, *however*, I changed the logic of the function, meaning the backend, when receiving the `GET users/leaderboard` request, fetches all stored users and based on the points achieved it assigns a rank, the rank is then included in the response
- the player with most points is ranked 1st
- if all players have zero points then the newer ones are ranked lower (maybe we need to change this or apply logic in frontend)