### PR TITLE
#57: changed join room endpoint

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/RoomController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/RoomController.java
@@ -43,16 +43,15 @@ public class RoomController {
         );
     }
 
-    @PostMapping("/rooms/{roomId}/players")
+    @PostMapping("/rooms/players")
     @ResponseStatus(HttpStatus.OK)
-    public RoomDTO joinRoom(@PathVariable("roomId") Long roomId, 
-            @RequestHeader(value = "userId", required = false) Long userId, 
-            @RequestHeader(value = "token", required = false) String token,
-            @RequestHeader(value = "roomJoinCode", required = false) String roomJoinCode) {
-                
-                Room joinedRoom = roomService.joinRoom(roomId, roomJoinCode, userId, token);
-                return DTOMapper.INSTANCE.convertEntityToRoomDTO(joinedRoom);
-            }
+    public RoomDTO joinRoom(@RequestHeader(value = "userId", required = false) Long userId, 
+                            @RequestHeader(value = "token", required = false) String token,
+                            @RequestHeader(value = "roomJoinCode", required = false) String roomJoinCode) {
+                                
+                                Room joinedRoom = roomService.joinRoom(roomJoinCode, userId, token);
+                                return DTOMapper.INSTANCE.convertEntityToRoomDTO(joinedRoom);
+    }
 
 
     @GetMapping("/rooms/{roomId}")

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/RoomService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/RoomService.java
@@ -52,17 +52,18 @@ public class RoomService {
         return createdRoom;
     }
 
-    public Room joinRoom(Long roomId, String roomJoinCode, Long userId, String token) {
+    public Room joinRoom(String roomJoinCode, Long userId, String token) {
         userService.verifyTokenAndUserId(token, userId);
         User newPlayer = userService.getUserbyId(userId);
 
-        Room targetRoom = roomRepository.findByRoomId(roomId);
+        if (!roomJoinCode.matches("[A-F0-9]{6}")) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid code!");
+        }
+
+        Room targetRoom = roomRepository.findByRoomJoinCode(roomJoinCode);
 
         if (targetRoom == null) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Room was not found!");
-        }
-        else if (!targetRoom.getRoomJoinCode().equals(roomJoinCode)){
-            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Insufficient permission to join room!");
         }
         else if(!targetRoom.isRoomOpen()){
             throw new ResponseStatusException(HttpStatus.CONFLICT, "Cannot join room: already full!");

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/RoomControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/RoomControllerTest.java
@@ -215,9 +215,9 @@ class RoomControllerTest {
         joiningUser.setId(5L);
         joiningUser.setToken("validToken");
         
-        Mockito.when(roomService.joinRoom(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any())).thenReturn(room);
+        Mockito.when(roomService.joinRoom(Mockito.any(), Mockito.any(), Mockito.any())).thenReturn(room);
         
-        MockHttpServletRequestBuilder postRequest = post("/rooms/{roomId}/players", room.getRoomId())
+        MockHttpServletRequestBuilder postRequest = post("/rooms/players")
                 .header("token", joiningUser.getToken())
                 .header("userId", joiningUser.getId())
                 .header("roomJoinCode", room.getRoomJoinCode())
@@ -240,47 +240,63 @@ class RoomControllerTest {
                 .andExpect(jsonPath("$.numOfProblems").isEmpty());
         }
 
+        // Join Room Fail 400 (1)
+        @Test
+        void failedJoinRoom_invalidFormattedJoinRoomCode1() throws Exception {
+        
+        String badFormattedRoomJoinCode = "ABC5432"; //has to match regex expression: [A-F0-9]{6}
+
+        String errorReason = "Invalid code!";
+	given(roomService.joinRoom(Mockito.any(), Mockito.any(), Mockito.any())).willThrow(new ResponseStatusException(HttpStatus.BAD_REQUEST, errorReason));
+        
+        MockHttpServletRequestBuilder postRequest = post("/rooms/players")
+                .header("token", "validToken")
+                .header("userId", "1")
+                .header("roomJoinCode", badFormattedRoomJoinCode)
+                .contentType("application/json");
+
+        mockMvc.perform(postRequest)
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.detail", is(errorReason)));
+        }
+
+        // Join Room Fail 400 (2)
+        @Test
+        void failedJoinRoom_invalidFormattedJoinRoomCode2() throws Exception {
+        
+        String badFormattedRoomJoinCode = "aBC456"; //has to match regex expression: [A-F0-9]{6}
+
+        String errorReason = "Invalid code!";
+	given(roomService.joinRoom(Mockito.any(), Mockito.any(), Mockito.any())).willThrow(new ResponseStatusException(HttpStatus.BAD_REQUEST, errorReason));
+        
+        MockHttpServletRequestBuilder postRequest = post("/rooms/players")
+                .header("token", "validToken")
+                .header("userId", "1")
+                .header("roomJoinCode", badFormattedRoomJoinCode)
+                .contentType("application/json");
+
+        mockMvc.perform(postRequest)
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.detail", is(errorReason)));
+        }
+
         // Join Room Fail 404
         @Test
         void failedJoinRoom_roomDoesNotExist() throws Exception {
         
-        Long notExistingRoomId = 7L; //arbitrary roomId simulating a non-existing one
+        String notExistingRoomJoinCode = "ABC454"; //arbitrary well-formatted roomJoinCode that is not associated to any room
 
         String errorReason = "Room was not found!";
-	given(roomService.joinRoom(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any())).willThrow(new ResponseStatusException(HttpStatus.NOT_FOUND, errorReason));
+	given(roomService.joinRoom(Mockito.any(), Mockito.any(), Mockito.any())).willThrow(new ResponseStatusException(HttpStatus.NOT_FOUND, errorReason));
         
-        MockHttpServletRequestBuilder postRequest = post("/rooms/{roomId}/players", notExistingRoomId)
+        MockHttpServletRequestBuilder postRequest = post("/rooms/players")
                 .header("token", "validToken")
                 .header("userId", "1")
-                .header("roomJoinCode", "ABC456")
+                .header("roomJoinCode", notExistingRoomJoinCode)
                 .contentType("application/json");
 
         mockMvc.perform(postRequest)
                 .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.detail", is(errorReason)));
-        }
-
-        // Join Room Fail 403
-        @Test
-        void failedJoinRoom_invalidRoomJoinCode() throws Exception {
-        
-        Room room = new Room();
-        room.setRoomId(2L);
-        room.setRoomJoinCode("FCZ123");
-
-        String invalidRoomJoinCode = "GCZ123"; //invalid roomJoinCode
-
-        String errorReason = "Insufficient permission to join room!";
-	given(roomService.joinRoom(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any())).willThrow(new ResponseStatusException(HttpStatus.FORBIDDEN, errorReason));
-        
-        MockHttpServletRequestBuilder postRequest = post("/rooms/{roomId}/players", room.getRoomId())
-                .header("token", "validToken")
-                .header("userId", "1")
-                .header("roomJoinCode", invalidRoomJoinCode)
-                .contentType("application/json");
-
-        mockMvc.perform(postRequest)
-                .andExpect(status().isForbidden())
                 .andExpect(jsonPath("$.detail", is(errorReason)));
         }
 
@@ -290,16 +306,16 @@ class RoomControllerTest {
         
         Room room = new Room();
         room.setRoomId(2L);
-        room.setRoomJoinCode("ABC170");
+        room.setRoomJoinCode("ABC123");
         room.setRoomOpen(false); //room is closed
 
         String errorReason = "Cannot join room: already full!";
-	given(roomService.joinRoom(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any())).willThrow(new ResponseStatusException(HttpStatus.CONFLICT, errorReason));
+	given(roomService.joinRoom(Mockito.any(), Mockito.any(), Mockito.any())).willThrow(new ResponseStatusException(HttpStatus.CONFLICT, errorReason));
         
-        MockHttpServletRequestBuilder postRequest = post("/rooms/{roomId}/players", room.getRoomId())
+        MockHttpServletRequestBuilder postRequest = post("/rooms/players")
                 .header("token", "validToken")
                 .header("userId", "1")
-                .header("roomJoinCode", "ABC170")
+                .header("roomJoinCode", "ABC123")
                 .contentType("application/json");
 
         mockMvc.perform(postRequest)

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/repository/RoomRepositoryIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/repository/RoomRepositoryIntegrationTest.java
@@ -64,6 +64,45 @@ class RoomRepositoryIntegrationTest {
 		assertEquals(room.getTimeLimitSeconds(), foundRoom.getTimeLimitSeconds());
 		assertEquals(room.getNumOfProblems(), foundRoom.getNumOfProblems());
 	}
+
+	@Test
+	void findByRoomJoinCode_sucess() {
+		//given
+		Room room = new Room();
+		room.setRoomJoinCode("CEF879");
+		room.setMaxNumPlayers(2);
+		room.setCurrentNumPlayers(1);
+		room.setRoomOpen(true);
+		room.setHostUserId(1L);
+		room.setPlayerIds(new HashSet<>(Set.of(1L)));
+		room.setGameDifficulty(GameDifficulty.HARD);
+		room.setGameLanguage(GameLanguage.JAVA);
+		room.setGameMode(GameMode.RACE);
+		room.setMaxSkips(2);
+		room.setTimeLimitSeconds(600);
+		room.setNumOfProblems(10);
+
+		entityManager.persist(room);
+		entityManager.flush();
+
+		// when
+		Room foundRoom = roomRepository.findByRoomJoinCode(room.getRoomJoinCode());
+
+		//then
+		assertNotNull(foundRoom.getRoomId());
+		assertEquals(room.getRoomJoinCode(), foundRoom.getRoomJoinCode());
+		assertEquals(room.getMaxNumPlayers(), foundRoom.getMaxNumPlayers());
+		assertEquals(room.getCurrentNumPlayers(), foundRoom.getCurrentNumPlayers());
+		assertEquals(room.isRoomOpen(), foundRoom.isRoomOpen());
+		assertEquals(room.getHostUserId(), foundRoom.getHostUserId());
+		assertEquals(room.getPlayerIds(), foundRoom.getPlayerIds());
+		assertEquals(room.getGameDifficulty(), foundRoom.getGameDifficulty());
+		assertEquals(room.getGameLanguage(), foundRoom.getGameLanguage());
+		assertEquals(room.getGameMode(), foundRoom.getGameMode());
+		assertEquals(room.getMaxSkips(), foundRoom.getMaxSkips());
+		assertEquals(room.getTimeLimitSeconds(), foundRoom.getTimeLimitSeconds());
+		assertEquals(room.getNumOfProblems(), foundRoom.getNumOfProblems());
+	}
 	
 	@Test
 	void lockedFieldsAreNotUpdatedAfterRoomCreation_success() {

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/RoomServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/RoomServiceTest.java
@@ -52,7 +52,7 @@ class RoomServiceTest {
 
         testRoom = new Room();
         testRoom.setRoomId(9L);
-        testRoom.setRoomJoinCode("ALE123");
+        testRoom.setRoomJoinCode("ABC123");
         testRoom.setRoomOpen(true);
         testRoom.setCurrentNumPlayers(1);
         Set<Long> playerIds = new HashSet<>();
@@ -188,9 +188,9 @@ class RoomServiceTest {
     void joinRoom_validInputs_success() {
 
         given(userService.getUserbyId(2L)).willReturn(testUser);
-        given(roomRepository.findByRoomId(9L)).willReturn(testRoom);
+        given(roomRepository.findByRoomJoinCode("ABC123")).willReturn(testRoom);
 
-        Room resultRoom = roomService.joinRoom(9L, "ALE123", 2L, "validToken");
+        Room resultRoom = roomService.joinRoom("ABC123", 2L, "validToken");
 
         assertTrue(resultRoom.getPlayerIds().contains(2L));
         assertEquals(2, resultRoom.getPlayerIds().size());
@@ -199,23 +199,49 @@ class RoomServiceTest {
         verify(roomRepository).save(testRoom);
     }
 
+    //Join room fail (400) 1
+    @Test
+    void failedjoinRoom_badFormattedRoomJoinCode_throwsNotFound1() {
+        given(userService.getUserbyId(2L)).willReturn(testUser);
+
+        assertThrows(ResponseStatusException.class, () ->
+                roomService.joinRoom("ABc123", 2L, "validToken"));
+    }
+
+    //Join room fail (400) 2
+    @Test
+    void failedjoinRoom_badFormattedRoomJoinCode_throwsNotFound2() {
+        given(userService.getUserbyId(2L)).willReturn(testUser);
+
+        assertThrows(ResponseStatusException.class, () ->
+                roomService.joinRoom("ABC1234", 2L, "validToken"));
+    }
+
+    //Join room fail (400) 3
+    @Test
+    void failedjoinRoom_badFormattedRoomJoinCode_throwsNotFound3() {
+        given(userService.getUserbyId(2L)).willReturn(testUser);
+
+        assertThrows(ResponseStatusException.class, () ->
+                roomService.joinRoom("ABC12", 2L, "validToken"));
+    }
+
+    //Join room fail (400) 4
+    @Test
+    void failedjoinRoom_badFormattedRoomJoinCode_throwsNotFound4() {
+        given(userService.getUserbyId(2L)).willReturn(testUser);
+
+        assertThrows(ResponseStatusException.class, () ->
+                roomService.joinRoom("ABG123", 2L, "validToken"));
+    }
+
     //Join room fail (404)
     @Test
     void failedjoinRoom_roomNotFound_throwsNotFound() {
-        given(roomRepository.findByRoomId(any())).willReturn(null);
+        given(roomRepository.findByRoomJoinCode(any())).willReturn(null);
 
         assertThrows(ResponseStatusException.class, () ->
-                roomService.joinRoom(19L, "ALE123", 2L, "validToken"));
-    }
-
-    //Join room fail (403)
-    @Test
-    void failedjoinRoom_invalidRoomJoinCode_throwsForbidden() {
-        given(userService.getUserbyId(2L)).willReturn(testUser);
-        given(roomRepository.findByRoomId(9L)).willReturn(testRoom);
-
-        assertThrows(ResponseStatusException.class, () ->
-                roomService.joinRoom(9L, "wrongRoomJoinCode", 2L, "validToken"));
+                roomService.joinRoom("ABC123", 2L, "validToken"));
     }
 
     //Join room fail (409)
@@ -223,10 +249,10 @@ class RoomServiceTest {
     void failedjoinRoom_roomIsNotOpen_throwsConflict() {
         testRoom.setRoomOpen(false); //room already closed, no entry possible anymore
         given(userService.getUserbyId(2L)).willReturn(testUser);
-        given(roomRepository.findByRoomId(9L)).willReturn(testRoom);
+        given(roomRepository.findByRoomJoinCode("ABC123")).willReturn(testRoom);
 
         assertThrows(ResponseStatusException.class, () ->
-                roomService.joinRoom(9L, "ALE123", 2L, "validToken"));
+                roomService.joinRoom("ABC123", 2L, "validToken"));
     }
 
     //Join room fail (500; very defensive coding, this should never happen!)
@@ -234,9 +260,9 @@ class RoomServiceTest {
     void failedjoinRoom_roomIsInInvalidState_throwsInteralServerError() {
         testRoom.setCurrentNumPlayers(2); //should be only 1, since only host in room when another player joins
         given(userService.getUserbyId(2L)).willReturn(testUser);
-        given(roomRepository.findByRoomId(9L)).willReturn(testRoom);
+        given(roomRepository.findByRoomJoinCode("ABC123")).willReturn(testRoom);
 
         assertThrows(ResponseStatusException.class, () ->
-                roomService.joinRoom(9L, "ALE123", 2L, "validToken"));
+                roomService.joinRoom("ABC123", 2L, "validToken"));
     }
 }


### PR DESCRIPTION
- changed the endpoint regarding joining a room, such that the `roomId` is no longer needed when making the request from client
- now `roomJoinCode` is the main field: it is validated in backend and used to retrieve the requested room (if available)