### PR TITLE
still trying to debug ws, now trying with SockJS

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/config/WebSocketConfig.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/config/WebSocketConfig.java
@@ -31,8 +31,8 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) { 
         registry.addEndpoint("/ws") //'ws' is the endpoint where clients establish connection (controller methods are associated to this endpoint)
-                .setAllowedOriginPatterns("*"); //CHANGE THIS SETTING when it works to prevent untrusted domains to make requests
-                // .withSockJS(); //fallback when native WebSockets are not supported (then: emulates HTTP-behaviour)
+                .setAllowedOriginPatterns("*") //CHANGE THIS SETTING when it works to prevent untrusted domains to make requests
+                .withSockJS(); //fallback when native WebSockets are not supported (then: emulates HTTP-behaviour)
                 
     }
 }


### PR DESCRIPTION
- with manu, we are trying to debug the websocket connection, it works locally but something does not work with google app engine, apparently, native websocket support is not supported well by google app engine, now we tried to integrate the `withSockJS()` function which serves as fallback when native ws connection does not work.