### PR TITLE
set autoscale limit of instances to 1

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -3,3 +3,6 @@
 
 runtime: java17
 instance_class: F2
+
+automatic_scaling:
+  max_instances: 1


### PR DESCRIPTION
- We are still trying to understand why the WebSocket connection works in dev mode but not in deployed version.
- We believe that it has to do with the nature of the `Standard environment` of App Engine (that we currently use), since, as far as we can tell, it does not support WebSockets as mentioned in [App Engine docs: Choose an App Engine environment](https://docs.cloud.google.com/appengine/docs/the-appengine-environments)
- The problem with the Standard environment is that as soon as it receives a good amount of requests it spins up multiple instances and App Engine, apparently, distributes the traffic evenly among those instances (as stated here: [App Engine docs: Creating persistent connections with WebSockets](https://docs.cloud.google.com/appengine/docs/flexible/using-websockets-and-session-affinity?tab=java#top)). However, since native WebSockets are not supported and we have to rely on `http long polling` instead, the multiple instances can cause problems. As stated in the aforementioned source, in order for http long polling to work the requests made by the client have to always reach the *exact same instance*, if that's not the case then the connection can fail and it can end up in an infinite loop where the client retries to establish connection (as we experienced this morning). That's why we want to try it by limiting the instances, when App Engine auto-scales, to 1. Obviously, this configuration might create other problems such as degraded performance or that the one instance might collapse if traffic is very high but we still want to try it. 

- **Two other potential possibilities** to tackle this problem are:
1.  Enable `session affinity`: This would allow the client to send the requests to the same instance, however, as stated in [App Engine Doc](https://docs.cloud.google.com/appengine/docs/flexible/using-websockets-and-session-affinity?tab=java#top), "Session affinity in App Engine is implemented on a best-effort basis" and is not guaranteed
2. Another possibility might be to upgrade the environment from `Standard environment` to `Flexible environment`, since the latter supports WebSockets. However, we have to monitor the costs very well if choosing to work with the flexible env.