### PR TITLE
Integrated judge0. Part 2/2 (#131)

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/constant/Verdict.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/constant/Verdict.java
@@ -7,6 +7,11 @@ package ch.uzh.ifi.hase.soprafs26.constant;
  * We can then use these definitions across the app
  */
 public enum Verdict {
-     CORRECT_ANSWER, WRONG_ANSWER, COMPILE_ERROR
+     PENDING, // If the submission is still being judged, the verdict is pending
+     CORRECT_ANSWER, // If all results are correct answer, the whole submission is correct answer
+     WRONG_ANSWER, // If any result is wrong answer, the whole submission is wrong answer
+     COMPILE_ERROR, // If any result is compile error, the whole submission is compile error
+     TIME_LIMIT_EXCEEDED, // if any result is time limit exceeded, the whole submission is time limit exceeded
+     INTERNAL_ERROR // If something is really wrong with our backend (this makes it easier for us to debug internally)
     
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/CodeExecutionController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/CodeExecutionController.java
@@ -22,7 +22,7 @@ public class CodeExecutionController {
         this.codeExecutionService = codeExecutionService;
     }
 
-    @PostMapping("/games/{gameSessionId}/problems/{problemId}/run")
+    @PostMapping("/games/{gameSessionId}/problems/{problemId}/runs")
     @ResponseStatus(HttpStatus.OK)
     public CodeRunDTO runCode(@PathVariable Long gameSessionId,
                               @PathVariable Long problemId,
@@ -31,7 +31,7 @@ public class CodeExecutionController {
         return codeExecutionService.runCode(gameSessionId, problemId, requestBody);
     }
 
-    @PostMapping("/games/{gameSessionId}/problems/{problemId}/submission")
+    @PostMapping("/games/{gameSessionId}/problems/{problemId}/submissions")
     @ResponseStatus(HttpStatus.OK)
     public CodeSubmissionDTO submitCode(@PathVariable Long gameSessionId,
                                         @PathVariable Long problemId,

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/CodeExecutionController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/CodeExecutionController.java
@@ -1,18 +1,17 @@
 package ch.uzh.ifi.hase.soprafs26.controller;
 
-import ch.uzh.ifi.hase.soprafs26.service.CodeExecutionService;
-import org.springframework.web.bind.annotation.RestController;
-
 import ch.uzh.ifi.hase.soprafs26.rest.dto.CodeExecutionPostDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.CodeRunDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.CodeSubmissionDTO;
-
+import ch.uzh.ifi.hase.soprafs26.service.CodeExecutionService;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
-
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 public class CodeExecutionController {
@@ -23,21 +22,39 @@ public class CodeExecutionController {
         this.codeExecutionService = codeExecutionService;
     }
 
-    @PostMapping("/games/{gameSessionId}/problems/{problemId}/runs")
+    @PostMapping("/games/{gameSessionId}/problems/{problemId}/run")
     @ResponseStatus(HttpStatus.OK)
-    public CodeRunDTO runCode(@PathVariable long gameSessionId,
-                              @PathVariable  long problemId,
+    public CodeRunDTO runCode(@PathVariable Long gameSessionId,
+                              @PathVariable Long problemId,
                               @RequestBody CodeExecutionPostDTO requestBody) {
-        
+
         return codeExecutionService.runCode(gameSessionId, problemId, requestBody);
     }
 
-    @PostMapping("/games/{gameSessionId}/problems/{problemId}/submissions")
+    @PostMapping("/games/{gameSessionId}/problems/{problemId}/submission")
     @ResponseStatus(HttpStatus.OK)
-    public CodeSubmissionDTO submitCode(@PathVariable long gameSessionId,
-                                        @PathVariable  long problemId,
+    public CodeSubmissionDTO submitCode(@PathVariable Long gameSessionId,
+                                        @PathVariable Long problemId,
                                         @RequestBody CodeExecutionPostDTO requestBody) {
 
         return codeExecutionService.submitCode(gameSessionId, problemId, requestBody);
+    }
+
+    @GetMapping("/games/{gameSessionId}/problems/{problemId}/run-result")
+    @ResponseStatus(HttpStatus.OK)
+    public CodeRunDTO getRunResult(@PathVariable Long gameSessionId,
+                                   @PathVariable Long problemId,
+                                   @RequestParam Long playerSessionId) {
+
+        return codeExecutionService.getLatestRunResult(gameSessionId, problemId, playerSessionId);
+    }
+
+    @GetMapping("/games/{gameSessionId}/problems/{problemId}/submission-result")
+    @ResponseStatus(HttpStatus.OK)
+    public CodeSubmissionDTO getSubmissionResult(@PathVariable Long gameSessionId,
+                                                 @PathVariable Long problemId,
+                                                 @RequestParam Long playerSessionId) {
+
+        return codeExecutionService.getLatestSubmissionResult(gameSessionId, problemId, playerSessionId);
     }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Submission.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Submission.java
@@ -62,6 +62,10 @@ public class Submission implements Serializable { // Careful submission doesn't 
     @Column(nullable = true, columnDefinition = "TEXT")
     private String judgeTokensJson;
 
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String judgeResultJson; // For the user to debug
+
     /**
      * 1:1 Relationship
      * CascadeType.ALL means if you save/delete the Submission, it will cascade 
@@ -184,4 +188,14 @@ public class Submission implements Serializable { // Careful submission doesn't 
     public void setVerdict(Verdict verdict) {
         this.verdict = verdict;
     }
+
+    public String getJudgeResultsJson() {
+        return judgeResultJson;
+    }
+
+    public void setJudgeResultsJson(String judgeResultsJson) {
+        this.judgeResultJson = judgeResultsJson;
+    }
+  
+
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Submission.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Submission.java
@@ -7,6 +7,7 @@ import java.time.LocalDateTime;
 
 import ch.uzh.ifi.hase.soprafs26.constant.SubmissionStatus;
 import ch.uzh.ifi.hase.soprafs26.constant.SubmissionType;
+import ch.uzh.ifi.hase.soprafs26.constant.Verdict;
 
 /**
  * Defines how submission is to be stored in the DB
@@ -24,6 +25,10 @@ public class Submission implements Serializable { // Careful submission doesn't 
     @Id
     @GeneratedValue
     private Long submissionId; // Primary key
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Verdict verdict;
 
     @Column(nullable = false, columnDefinition="TEXT") // This lets us store superlong strings
     private String sourceCode;
@@ -170,5 +175,13 @@ public class Submission implements Serializable { // Careful submission doesn't 
 
     public void setPlayerSessionId(Long playerSessionId) {
         this.playerSessionId = playerSessionId;
+    }
+
+    public Verdict getVerdict() {
+        return verdict;
+    }
+
+    public void setVerdict(Verdict verdict) {
+        this.verdict = verdict;
     }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/SubmissionRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/SubmissionRepository.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Repository;
 
 import ch.uzh.ifi.hase.soprafs26.constant.SubmissionType;
 import ch.uzh.ifi.hase.soprafs26.entity.Submission;
+import java.time.LocalDateTime;
 
 @Repository("submissionRepository")
 public interface SubmissionRepository extends JpaRepository<Submission, Long> {
@@ -23,5 +24,13 @@ public interface SubmissionRepository extends JpaRepository<Submission, Long> {
         Long problemId,
         Long playerSessionId,
         SubmissionType type
+    );
+
+    long countByGameSessionIdAndProblemIdAndPlayerSessionIdAndTypeAndSubmittedAtAfter(
+        Long gameSessionId,
+        Long problemId,
+        Long playerSessionId,
+        SubmissionType type,
+        LocalDateTime submittedAt
     );
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/SubmissionRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/SubmissionRepository.java
@@ -17,4 +17,11 @@ public interface SubmissionRepository extends JpaRepository<Submission, Long> {
     );
 
     Submission findBySubmissionId(Long submissionId);
+
+    Submission findTopByGameSessionIdAndProblemIdAndPlayerSessionIdAndTypeOrderBySubmissionIdDesc( // long long ah name part 2 💀💀
+        Long gameSessionId,
+        Long problemId,
+        Long playerSessionId,
+        SubmissionType type
+    );
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/CodeRunDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/CodeRunDTO.java
@@ -13,6 +13,9 @@ public class CodeRunDTO {
     private List<String> tokens;
     private SubmissionStatus submissionStatus;
     private Verdict verdict;
+    private String judgeResultsJson;
+    private int passedTestCases;
+    private int totalTestCases;
 
     public Long getGameSessionId() {
         return gameSessionId;
@@ -61,4 +64,29 @@ public class CodeRunDTO {
     public void setVerdict(Verdict verdict) {
         this.verdict = verdict;
     }
+
+    public String getJudgeResultsJson() {
+        return judgeResultsJson;
+    }
+
+    public void setJudgeResultsJson(String judgeResultsJson) {
+        this.judgeResultsJson = judgeResultsJson;
+    }
+
+    public int getPassedTestCases() {
+        return passedTestCases;
+    }
+
+    public void setPassedTestCases(int passedTestCases) {
+        this.passedTestCases = passedTestCases;
+    }
+
+    public int getTotalTestCases() {
+        return totalTestCases;
+    }
+
+    public void setTotalTestCases(int totalTestCases) {
+        this.totalTestCases = totalTestCases;
+    }
+
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/CodeRunDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/CodeRunDTO.java
@@ -2,12 +2,17 @@ package ch.uzh.ifi.hase.soprafs26.rest.dto;
 
 import java.util.List;
 
+import ch.uzh.ifi.hase.soprafs26.constant.SubmissionStatus;
+import ch.uzh.ifi.hase.soprafs26.constant.Verdict;
+
 public class CodeRunDTO {
 
     private Long gameSessionId;
     private Long problemId;
     private Long playerSessionId;
     private List<String> tokens;
+    private SubmissionStatus submissionStatus;
+    private Verdict verdict;
 
     public Long getGameSessionId() {
         return gameSessionId;
@@ -39,5 +44,21 @@ public class CodeRunDTO {
 
     public void setTokens(List<String> tokens) {
         this.tokens = tokens;
+    }
+
+    public SubmissionStatus getSubmissionStatus() {
+        return submissionStatus;
+    }
+
+    public void setSubmissionStatus(SubmissionStatus submissionStatus) {
+        this.submissionStatus = submissionStatus;
+    }
+
+    public Verdict getVerdict() {
+        return verdict;
+    }
+
+    public void setVerdict(Verdict verdict) {
+        this.verdict = verdict;
     }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/CodeSubmissionDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/CodeSubmissionDTO.java
@@ -2,12 +2,17 @@ package ch.uzh.ifi.hase.soprafs26.rest.dto;
 
 import java.util.List;
 
+import ch.uzh.ifi.hase.soprafs26.constant.SubmissionStatus;
+import ch.uzh.ifi.hase.soprafs26.constant.Verdict;
+
 public class CodeSubmissionDTO {
 
     private Long gameSessionId;
     private Long problemId;
     private Long playerSessionId;
     private List<String> tokens;
+    private SubmissionStatus submissionStatus;  
+    private Verdict verdict;
 
     public Long getGameSessionId() {
         return gameSessionId;
@@ -40,4 +45,21 @@ public class CodeSubmissionDTO {
     public void setTokens(List<String> tokens) {
         this.tokens = tokens;
     }
+
+    public SubmissionStatus getSubmissionStatus() {
+        return submissionStatus;
+    }
+
+    public void setSubmissionStatus(SubmissionStatus submissionStatus) {
+        this.submissionStatus = submissionStatus;
+    }
+
+    public Verdict getVerdict() {
+        return verdict;
+    }
+
+    public void setVerdict(Verdict verdict) {
+        this.verdict = verdict;
+    }
+    
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/CodeSubmissionDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/CodeSubmissionDTO.java
@@ -13,6 +13,9 @@ public class CodeSubmissionDTO {
     private List<String> tokens;
     private SubmissionStatus submissionStatus;  
     private Verdict verdict;
+    private String judgeResultsJson;
+    private int passedTestCases;
+    private int totalTestCases;
 
     public Long getGameSessionId() {
         return gameSessionId;
@@ -60,6 +63,30 @@ public class CodeSubmissionDTO {
 
     public void setVerdict(Verdict verdict) {
         this.verdict = verdict;
+    }
+
+    public String getJudgeResultsJson() {
+        return judgeResultsJson;
+    }
+
+    public void setJudgeResultsJson(String judgeResultsJson) {
+        this.judgeResultsJson = judgeResultsJson;
+    }
+
+    public int getPassedTestCases() {
+        return passedTestCases;
+    }
+
+    public void setPassedTestCases(int passedTestCases) {
+        this.passedTestCases = passedTestCases;
+    }
+
+    public int getTotalTestCases() {
+        return totalTestCases;
+    }
+
+    public void setTotalTestCases(int totalTestCases) {
+        this.totalTestCases = totalTestCases;
     }
     
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/JudgeBatchRequestDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/JudgeBatchRequestDTO.java
@@ -1,9 +1,12 @@
 package ch.uzh.ifi.hase.soprafs26.rest.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 
 public class JudgeBatchRequestDTO {
 
+    // Forces this list to be named "submissions" in the JSON
+    @JsonProperty("submissions")
     private List<JudgeRequestDTO> submissions;
 
     public List<JudgeRequestDTO> getSubmissions() {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/JudgeBatchResultDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/JudgeBatchResultDTO.java
@@ -1,0 +1,15 @@
+package ch.uzh.ifi.hase.soprafs26.rest.dto;
+import java.util.List;
+
+public class JudgeBatchResultDTO {
+    
+    private List<JudgeResultDTO> submissions;
+
+    public List<JudgeResultDTO> getSubmissions() {
+        return submissions;
+    }
+    
+    public void setSubmissions(List<JudgeResultDTO> submissions) {
+        this.submissions = submissions;
+    }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/JudgeRequestDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/JudgeRequestDTO.java
@@ -1,10 +1,19 @@
 package ch.uzh.ifi.hase.soprafs26.rest.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public class JudgeRequestDTO {
 
+    @JsonProperty("source_code")
     private String source_code;
+    
+    @JsonProperty("language_id")
     private Integer language_id;
+    
+    @JsonProperty("stdin")
     private String stdin;
+    
+    @JsonProperty("expected_output")
     private String expected_output;
 
     public String getSource_code() {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/JudgeResultDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/JudgeResultDTO.java
@@ -1,0 +1,63 @@
+package ch.uzh.ifi.hase.soprafs26.rest.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class JudgeResultDTO {
+    
+    private String token;
+    private String stdout;
+    private String stderr;
+    @JsonProperty("compile_output")
+    private String compileOutput;
+    
+    private String message;
+    private JudgeStatusDTO status;
+
+    public String getToken() {
+        return token;
+    }
+    public void setToken(String token) {
+        this.token = token;
+    }
+
+    public String getStdout() {
+        return stdout;
+    }
+    public void setStdout(String stdout) {
+        this.stdout = stdout;
+    }
+
+    public String getStderr() {
+        return stderr;
+    }
+
+    public void setStderr(String stderr) {
+        this.stderr = stderr;
+    }
+
+    public String getCompile_output() {
+        return compileOutput;
+    }
+
+    public void setCompile_output(String compile_output) {
+        this.compileOutput = compile_output;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public JudgeStatusDTO getStatus() {
+        return status;
+    }
+
+    public void setStatus(JudgeStatusDTO status) {
+        this.status = status;
+    }
+
+
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/JudgeStatusDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/JudgeStatusDTO.java
@@ -1,0 +1,21 @@
+package ch.uzh.ifi.hase.soprafs26.rest.dto;
+
+public class JudgeStatusDTO {
+    
+    private Integer id;
+    private String description;
+
+    public Integer getId() {
+        return id;
+    }
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+    public void setDescription(String description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/CodeExecutionService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/CodeExecutionService.java
@@ -183,6 +183,15 @@ public class CodeExecutionService {
         if (requestBody.getSourceCode() == null || requestBody.getSourceCode().isBlank()) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Source code is required");
         }
+
+        String code = requestBody.getSourceCode();
+        if (!code.contains("def solve")) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Your code must contain the function definition: def solve");
+        }
+        if (!code.contains("return")) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Your code must contain a return statement.");
+        }
+
     }
 
     private Submission createSubmission(long gameSessionId,
@@ -287,12 +296,25 @@ public class CodeExecutionService {
     }
 
     // This is basically the driver code as in leetcode but the user doesn't see it, so it doesnt clutter the screen
+    // This is basically the driver code as in leetcode but the user doesn't see it, so it doesnt clutter the screen
     private String wrapPythonCode(String userCode) {
         return userCode + "\n\n"
                 + "if __name__ == '__main__':\n"
                 + "    import sys\n"
+                + "    import ast\n"
                 + "    input_data = sys.stdin.read().strip()\n"
-                + "    result = solution(input_data)\n"
+                + "    try:\n"
+                + "        # Try to parse it as proper Python literals (like tuples, ints, or quoted strings)\n"
+                + "        args = ast.literal_eval(input_data) if input_data else ()\n"
+                + "    except (ValueError, SyntaxError):\n"
+                + "        # Fallback: if it lacks quotes (e.g., ekitike), treat it as a single raw string\n"
+                + "        args = (input_data,)\n"
+                + "    \n"
+                + "    # Safely unpack the arguments into the user's solve function\n"
+                + "    if isinstance(args, tuple):\n"
+                + "        result = solve(*args)\n"
+                + "    else:\n"
+                + "        result = solve(args)\n"
                 + "    print(result)\n";
     }
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/CodeExecutionService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/CodeExecutionService.java
@@ -241,7 +241,14 @@ public class CodeExecutionService {
         JudgeBatchRequestDTO batchRequest = new JudgeBatchRequestDTO();
         batchRequest.setSubmissions(submissions);
 
-        return judgeService.submitBatch(batchRequest);
+        List<JudgeTokenDTO> tokens = judgeService.submitBatch(batchRequest);
+        if (tokens == null || tokens.isEmpty()) {
+            throw new ResponseStatusException(
+                    HttpStatus.BAD_GATEWAY,
+                    "Judge0 returned no submission tokens"
+            );
+        }
+        return tokens;
     }
 
     private Integer mapLanguageToJudgeCode(GameLanguage gameLanguage) {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/CodeExecutionService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/CodeExecutionService.java
@@ -23,6 +23,7 @@ import org.springframework.web.server.ResponseStatusException;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.time.LocalDateTime;
 
 @Service
 @Transactional
@@ -33,6 +34,10 @@ public class CodeExecutionService {
     private final SubmissionRepository submissionRepository;
     private final ObjectMapper objectMapper = new ObjectMapper();
 
+    /**
+     * We will check the Judge0 results up to MAX_RESULT_CHECKS times with a delay 
+     * of RESULT_CHECK_DELAY_MS milliseconds in between.
+     */
     private static final int MAX_RESULT_CHECKS = 3;
     private static final long RESULT_CHECK_DELAY_MS = 1000;
 
@@ -51,6 +56,8 @@ public class CodeExecutionService {
                               CodeExecutionPostDTO requestBody) {
 
         validateRequest(gameSessionId, problemId, requestBody);
+        // Check if the user has made too many run requests recently (method is defined at the end)
+        enforceRunRateLimit(gameSessionId, problemId, requestBody.getPlayerSessionId()); 
 
         Problem problem = problemService.getProblemById(problemId);
         List<JudgeTokenDTO> tokens = sendCodeToJudge(problem, requestBody.getSourceCode());
@@ -73,14 +80,8 @@ public class CodeExecutionService {
                 .toList();
 
         JudgeBatchResultDTO batchResult = pollJudgeResults(judgeTokens);
-
-        if (areAllJudgeResultsFinal(batchResult)) {
-            submission.setStatus(SubmissionStatus.FINISHED);
-            submission.setVerdict(aggregateVerdict(batchResult));
-        } else {
-            submission.setStatus(SubmissionStatus.RUNNING);
-            submission.setVerdict(Verdict.PENDING);
-        }
+        // This method updates the submission with the results from Judge0 and sets the appropriate status and verdict
+        applyJudgeBatchResultToSubmission(submission, batchResult);
 
         submissionRepository.save(submission);
         submissionRepository.flush();
@@ -91,6 +92,9 @@ public class CodeExecutionService {
         response.setPlayerSessionId(requestBody.getPlayerSessionId());
         response.setSubmissionStatus(submission.getStatus());
         response.setVerdict(submission.getVerdict());
+        response.setPassedTestCases(submission.getPassedTestCases());
+        response.setTotalTestCases(submission.getTotalTestCases());
+        response.setJudgeResultsJson(submission.getJudgeResultsJson());
 
         return response;
     }
@@ -137,14 +141,8 @@ public class CodeExecutionService {
                 .toList();
 
         JudgeBatchResultDTO batchResult = pollJudgeResults(judgeTokens);
-
-        if (areAllJudgeResultsFinal(batchResult)) {
-            submission.setStatus(SubmissionStatus.FINISHED);
-            submission.setVerdict(aggregateVerdict(batchResult));
-        } else {
-            submission.setStatus(SubmissionStatus.RUNNING);
-            submission.setVerdict(Verdict.PENDING);
-        }
+        // This method updates the submission with the results from Judge0 and sets the appropriate status and verdict
+        applyJudgeBatchResultToSubmission(submission, batchResult);
 
         submissionRepository.save(submission);
         submissionRepository.flush();
@@ -155,6 +153,9 @@ public class CodeExecutionService {
         response.setPlayerSessionId(requestBody.getPlayerSessionId());
         response.setSubmissionStatus(submission.getStatus());
         response.setVerdict(submission.getVerdict());
+        response.setPassedTestCases(submission.getPassedTestCases());
+        response.setTotalTestCases(submission.getTotalTestCases());
+        response.setJudgeResultsJson(submission.getJudgeResultsJson());
 
         return response;
     }
@@ -202,6 +203,8 @@ public class CodeExecutionService {
         submission.setStatus(SubmissionStatus.PENDING);
         submission.setVerdict(Verdict.PENDING);
         submission.setExecutionResult(null);
+        submission.setPassedTestCases(0);
+        submission.setJudgeResultsJson("");
 
         try {
             submission.setJudgeTokensJson(objectMapper.writeValueAsString(judgeTokens));
@@ -276,6 +279,7 @@ public class CodeExecutionService {
         }
     }
 
+    // This is basically the driver code as in leetcode but the user doesn't see it, so it doesnt clutter the screen
     private String wrapPythonCode(String userCode) {
         return userCode + "\n\n"
                 + "if __name__ == '__main__':\n"
@@ -417,21 +421,33 @@ public class CodeExecutionService {
             return submission;
         }
 
-        List<String> judgeTokens = extractJudgeTokens(submission);
-        JudgeBatchResultDTO batchResult = judgeService.getBatchSubmissionResults(judgeTokens);
+        try {
+             List<String> judgeTokens = extractJudgeTokens(submission);
+            JudgeBatchResultDTO batchResult = judgeService.getBatchSubmissionResults(judgeTokens);
+            // This method updates the submission with the results from Judge0 and sets the appropriate status and verdict
+            applyJudgeBatchResultToSubmission(submission, batchResult);
 
-        if (areAllJudgeResultsFinal(batchResult)) {
-            submission.setStatus(SubmissionStatus.FINISHED);
-            submission.setVerdict(aggregateVerdict(batchResult));
-        } else {
-            submission.setStatus(SubmissionStatus.RUNNING);
-            submission.setVerdict(Verdict.PENDING);
+            submissionRepository.save(submission);
+            submissionRepository.flush();
+
+            return submission;
+ 
+        } catch (ResponseStatusException e) {
+            submission.setStatus(SubmissionStatus.FAILED);
+            submission.setVerdict(Verdict.INTERNAL_ERROR);
+            submissionRepository.save(submission);
+            submissionRepository.flush();
+            throw e;
+        } catch (Exception e) {
+            submission.setStatus(SubmissionStatus.FAILED);
+            submission.setVerdict(Verdict.INTERNAL_ERROR);
+            submissionRepository.save(submission);
+            submissionRepository.flush();
+            throw new ResponseStatusException(
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                "Failed to refresh Judge0 submission"
+            );
         }
-
-        submissionRepository.save(submission);
-        submissionRepository.flush();
-
-        return submission;
     }
 
     public CodeRunDTO getLatestRunResult(Long gameSessionId, Long problemId, Long playerSessionId) {
@@ -464,6 +480,9 @@ public class CodeExecutionService {
         response.setPlayerSessionId(playerSessionId);
         response.setSubmissionStatus(submission.getStatus());
         response.setVerdict(submission.getVerdict());
+        response.setPassedTestCases(submission.getPassedTestCases());
+        response.setTotalTestCases(submission.getTotalTestCases());
+        response.setJudgeResultsJson(submission.getJudgeResultsJson());
 
         return response;
     }
@@ -498,7 +517,79 @@ public class CodeExecutionService {
         response.setPlayerSessionId(playerSessionId);
         response.setSubmissionStatus(submission.getStatus());
         response.setVerdict(submission.getVerdict());
+        response.setPassedTestCases(submission.getPassedTestCases());
+        response.setTotalTestCases(submission.getTotalTestCases());
+        response.setJudgeResultsJson(submission.getJudgeResultsJson());
 
         return response;
     }
+
+    private int countPassedTestCases(JudgeBatchResultDTO batchResult) {
+        if (batchResult == null || batchResult.getSubmissions() == null || batchResult.getSubmissions().isEmpty()) {
+            return 0;
+        }
+        /**
+         * stream does: for each submission result in the batch result 
+         * check if the status is not null and if the status id is 3 
+         * (which corresponds to "Correct Answer" in Judge0)
+         * we count how many results satisfy this condition. 
+         * Finally we cast the count to an integer and return it.
+         */
+        return (int) batchResult.getSubmissions().stream()
+                .filter(result -> result.getStatus() != null
+                        && result.getStatus().getId() == 3) // 3 corresponds to "Correct Answer" in judge
+                .count();
+    }
+
+    private static final int MAX_RUN_REQUESTS_PER_WINDOW = 5; // amount of times the user can run in that window
+    private static final long RUN_RATE_LIMIT_WINDOW_SECONDS = 30; // the window in which we check if the user runs too many times
+
+    /**
+     * checks if the user has made too many run requests in a short period of time.
+     * This is too prevent the homeserver of blowing up
+     */
+    private void enforceRunRateLimit(Long gameSessionId, Long problemId, Long playerSessionId) {
+        // We check how many run submissions the user has made in the last RUN_RATE_LIMIT_WINDOW_SECONDS seconds
+        LocalDateTime windowStart = LocalDateTime.now().minusSeconds(RUN_RATE_LIMIT_WINDOW_SECONDS);
+        // We count the number of run submissions for this user, problem and game session that were submitted after the window start time
+        long recentRuns = submissionRepository.countByGameSessionIdAndProblemIdAndPlayerSessionIdAndTypeAndSubmittedAtAfter(
+                gameSessionId, // we check the runs for the same game session   
+                problemId, // we check the runs for the same problem
+                playerSessionId, // we check the runs for the same player session
+                SubmissionType.RUN, // we only check the run submissions and  not the final submissions since we can submit only once
+                windowStart // we only check the runs that were submitted after the window start time
+        );
+
+        if (recentRuns >= MAX_RUN_REQUESTS_PER_WINDOW) {
+            throw new ResponseStatusException(HttpStatus.TOO_MANY_REQUESTS, "You are running code too frequently. Please wait a moment before trying again."); // 429
+        }
+
+    }
+
+    private void applyJudgeBatchResultToSubmission(Submission submission, JudgeBatchResultDTO batchResult) {
+        if (submission == null) {
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Submission is null");
+        }
+
+        if (areAllJudgeResultsFinal(batchResult)) {
+            submission.setStatus(SubmissionStatus.FINISHED);
+            submission.setVerdict(aggregateVerdict(batchResult));
+            submission.setPassedTestCases(countPassedTestCases(batchResult));
+
+            try {
+                submission.setJudgeResultsJson(objectMapper.writeValueAsString(batchResult));
+            } catch (Exception e) {
+                submission.setStatus(SubmissionStatus.FAILED);
+                submission.setVerdict(Verdict.INTERNAL_ERROR);
+                throw new ResponseStatusException(
+                        HttpStatus.INTERNAL_SERVER_ERROR,
+                        "Failed to serialize Judge0 results"
+                );
+            }
+        } else {
+            submission.setStatus(SubmissionStatus.RUNNING);
+            submission.setVerdict(Verdict.PENDING);
+        }
+    }
+
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/CodeExecutionService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/CodeExecutionService.java
@@ -1,18 +1,9 @@
 package ch.uzh.ifi.hase.soprafs26.service;
 
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.server.ResponseStatusException;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import org.springframework.http.HttpStatus;
-
-
 import ch.uzh.ifi.hase.soprafs26.constant.GameLanguage;
 import ch.uzh.ifi.hase.soprafs26.constant.SubmissionStatus;
 import ch.uzh.ifi.hase.soprafs26.constant.SubmissionType;
+import ch.uzh.ifi.hase.soprafs26.constant.Verdict;
 import ch.uzh.ifi.hase.soprafs26.entity.Problem;
 import ch.uzh.ifi.hase.soprafs26.entity.Submission;
 import ch.uzh.ifi.hase.soprafs26.entity.TestCase;
@@ -21,18 +12,29 @@ import ch.uzh.ifi.hase.soprafs26.rest.dto.CodeExecutionPostDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.CodeRunDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.CodeSubmissionDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.JudgeBatchRequestDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.JudgeBatchResultDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.JudgeRequestDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.JudgeTokenDTO;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
 
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @Transactional
 public class CodeExecutionService {
-    
+
     private final ProblemService problemService;
     private final JudgeService judgeService;
     private final SubmissionRepository submissionRepository;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private static final int MAX_RESULT_CHECKS = 3;
+    private static final long RESULT_CHECK_DELAY_MS = 1000;
 
     public CodeExecutionService(
             ProblemService problemService,
@@ -42,44 +44,61 @@ public class CodeExecutionService {
         this.problemService = problemService;
         this.judgeService = judgeService;
         this.submissionRepository = submissionRepository;
-    }   
-
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    }
 
     public CodeRunDTO runCode(Long gameSessionId,
-                            Long problemId,
-                           CodeExecutionPostDTO requestBody) {
-        
+                              Long problemId,
+                              CodeExecutionPostDTO requestBody) {
+
         validateRequest(gameSessionId, problemId, requestBody);
 
         Problem problem = problemService.getProblemById(problemId);
-
         List<JudgeTokenDTO> tokens = sendCodeToJudge(problem, requestBody.getSourceCode());
 
-        Submission submission = createSubmission(gameSessionId, 
-                                                problemId, 
-                                                requestBody.getPlayerSessionId(),
-                                                requestBody.getSourceCode(),
-                                                SubmissionType.RUN,
-                                                problem.getTestCases().size(),
-                                                tokens);
+        Submission submission = createSubmission(
+                gameSessionId,
+                problemId,
+                requestBody.getPlayerSessionId(),
+                requestBody.getSourceCode(),
+                SubmissionType.RUN,
+                problem.getTestCases().size(),
+                tokens
+        );
 
-       submissionRepository.save(submission);
-       submissionRepository.flush();
-       
-       CodeRunDTO response = new CodeRunDTO();
-       response.setGameSessionId(gameSessionId);
-       response.setProblemId(problemId);
-       response.setPlayerSessionId(requestBody.getPlayerSessionId());
-       response.setTokens(tokens.stream().map(JudgeTokenDTO::getJudgeToken).toList());
+        submissionRepository.save(submission);
+        submissionRepository.flush();
 
-        
-       return response;
+        List<String> judgeTokens = tokens.stream()
+                .map(JudgeTokenDTO::getJudgeToken)
+                .toList();
+
+        JudgeBatchResultDTO batchResult = pollJudgeResults(judgeTokens);
+
+        if (areAllJudgeResultsFinal(batchResult)) {
+            submission.setStatus(SubmissionStatus.FINISHED);
+            submission.setVerdict(aggregateVerdict(batchResult));
+        } else {
+            submission.setStatus(SubmissionStatus.RUNNING);
+            submission.setVerdict(Verdict.PENDING);
+        }
+
+        submissionRepository.save(submission);
+        submissionRepository.flush();
+
+        CodeRunDTO response = new CodeRunDTO();
+        response.setGameSessionId(gameSessionId);
+        response.setProblemId(problemId);
+        response.setPlayerSessionId(requestBody.getPlayerSessionId());
+        response.setSubmissionStatus(submission.getStatus());
+        response.setVerdict(submission.getVerdict());
+
+        return response;
     }
 
     public CodeSubmissionDTO submitCode(Long gameSessionId,
                                         Long problemId,
                                         CodeExecutionPostDTO requestBody) {
+
         validateRequest(gameSessionId, problemId, requestBody);
 
         boolean alreadySubmitted = submissionRepository
@@ -98,7 +117,6 @@ public class CodeExecutionService {
         }
 
         Problem problem = problemService.getProblemById(problemId);
-
         List<JudgeTokenDTO> tokens = sendCodeToJudge(problem, requestBody.getSourceCode());
 
         Submission submission = createSubmission(
@@ -112,17 +130,38 @@ public class CodeExecutionService {
         );
 
         submissionRepository.save(submission);
+        submissionRepository.flush();
+
+        List<String> judgeTokens = tokens.stream()
+                .map(JudgeTokenDTO::getJudgeToken)
+                .toList();
+
+        JudgeBatchResultDTO batchResult = pollJudgeResults(judgeTokens);
+
+        if (areAllJudgeResultsFinal(batchResult)) {
+            submission.setStatus(SubmissionStatus.FINISHED);
+            submission.setVerdict(aggregateVerdict(batchResult));
+        } else {
+            submission.setStatus(SubmissionStatus.RUNNING);
+            submission.setVerdict(Verdict.PENDING);
+        }
+
+        submissionRepository.save(submission);
+        submissionRepository.flush();
 
         CodeSubmissionDTO response = new CodeSubmissionDTO();
         response.setGameSessionId(gameSessionId);
         response.setProblemId(problemId);
         response.setPlayerSessionId(requestBody.getPlayerSessionId());
-        response.setTokens(tokens.stream().map(JudgeTokenDTO::getJudgeToken).toList());
+        response.setSubmissionStatus(submission.getStatus());
+        response.setVerdict(submission.getVerdict());
 
         return response;
     }
 
-    public void validateRequest(Long gameSessionId, Long problemId, CodeExecutionPostDTO requestBody) {
+    private void validateRequest(Long gameSessionId,
+                                 Long problemId,
+                                 CodeExecutionPostDTO requestBody) {
 
         if (gameSessionId == null) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Game session ID is required");
@@ -132,11 +171,15 @@ public class CodeExecutionService {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Problem ID is required");
         }
 
+        if (requestBody == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Request body is required");
+        }
+
         if (requestBody.getPlayerSessionId() == null) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Player session ID is required");
         }
 
-        if (requestBody.getSourceCode() == null || requestBody.getSourceCode().isBlank()) { // isBlank checks for emptiness OR only whitespaces which fits better than isEmpty()
+        if (requestBody.getSourceCode() == null || requestBody.getSourceCode().isBlank()) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Source code is required");
         }
     }
@@ -148,6 +191,7 @@ public class CodeExecutionService {
                                         SubmissionType submissionType,
                                         int totalTestCases,
                                         List<JudgeTokenDTO> judgeTokens) {
+
         Submission submission = new Submission();
         submission.setGameSessionId(gameSessionId);
         submission.setProblemId(problemId);
@@ -156,16 +200,19 @@ public class CodeExecutionService {
         submission.setType(submissionType);
         submission.setTotalTestCases(totalTestCases);
         submission.setStatus(SubmissionStatus.PENDING);
+        submission.setVerdict(Verdict.PENDING);
         submission.setExecutionResult(null);
 
         try {
             submission.setJudgeTokensJson(objectMapper.writeValueAsString(judgeTokens));
         } catch (Exception e) {
-            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to serialize judge tokens");
+            throw new ResponseStatusException(
+                    HttpStatus.INTERNAL_SERVER_ERROR,
+                    "Failed to serialize Judge0 tokens"
+            );
         }
 
         return submission;
-
     }
 
     private List<JudgeTokenDTO> sendCodeToJudge(Problem problem, String userSourceCode) {
@@ -174,7 +221,7 @@ public class CodeExecutionService {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "This problem has no test cases");
         }
 
-        Integer languageId = mapLanguagetoJudgeCode(problem.getGameLanguage());
+        Integer languageId = mapLanguageToJudgeCode(problem.getGameLanguage());
         String wrappedSourceCode = wrapUserCode(userSourceCode, problem.getGameLanguage());
 
         List<JudgeRequestDTO> submissions = new ArrayList<>();
@@ -184,53 +231,53 @@ public class CodeExecutionService {
             request.setSource_code(wrappedSourceCode);
             request.setLanguage_id(languageId);
             request.setStdin(testCase.getInput());
-            request.setExpected_output(normalizeOutpuString(testCase.getExpectedOutput()));
+            request.setExpected_output(normalizeOutputString(testCase.getExpectedOutput()));
             submissions.add(request);
         }
 
         JudgeBatchRequestDTO batchRequest = new JudgeBatchRequestDTO();
         batchRequest.setSubmissions(submissions);
 
-        try {
-            objectMapper.writeValueAsString(batchRequest); // might remove later because we serialize it again manually later
-        }
-        catch (Exception e) {
-    throw new ResponseStatusException(
-            HttpStatus.INTERNAL_SERVER_ERROR,
-            "Failed to serialize batch request."
-            );
-        }
         return judgeService.submitBatch(batchRequest);
     }
 
-    private Integer mapLanguagetoJudgeCode(GameLanguage gameLanguage) {
+    private Integer mapLanguageToJudgeCode(GameLanguage gameLanguage) {
         if (gameLanguage == null) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Game language is required");
         }
 
-        switch(gameLanguage) {
+        switch (gameLanguage) {
             case PYTHON:
-                return 71; // Judge0 Code for Python3
+                return 71;
             case JAVA:
-                return 62; // Judge0 Code for Java
+                return 62;
             default:
-                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, gameLanguage + " is not a supported game language");
+                throw new ResponseStatusException(
+                        HttpStatus.BAD_REQUEST,
+                        gameLanguage + " is not a supported game language"
+                );
         }
     }
 
     private String wrapUserCode(String userCode, GameLanguage gameLanguage) {
-        switch(gameLanguage) {
+        switch (gameLanguage) {
             case PYTHON:
                 return wrapPythonCode(userCode);
             case JAVA:
-                throw new ResponseStatusException(HttpStatus.NOT_IMPLEMENTED, "Java is currently not supported for code execution");
+                throw new ResponseStatusException(
+                        HttpStatus.NOT_IMPLEMENTED,
+                        "Java is currently not supported for code execution"
+                );
             default:
-                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, gameLanguage + " wrapping is not supported");
+                throw new ResponseStatusException(
+                        HttpStatus.BAD_REQUEST,
+                        gameLanguage + " wrapping is not supported"
+                );
         }
     }
 
     private String wrapPythonCode(String userCode) {
-        return userCode + "\n\n" 
+        return userCode + "\n\n"
                 + "if __name__ == '__main__':\n"
                 + "    import sys\n"
                 + "    input_data = sys.stdin.read().strip()\n"
@@ -238,11 +285,220 @@ public class CodeExecutionService {
                 + "    print(result)\n";
     }
 
-    private String normalizeOutpuString(String expectedOutput) { // this is just to make sure expectedOutput is in the right  format
+    private String normalizeOutputString(String expectedOutput) {
         if (expectedOutput == null) {
             return "";
         }
         return expectedOutput.endsWith("\n") ? expectedOutput : expectedOutput + "\n";
     }
 
+    private boolean isFinalJudgeStatus(Integer statusId) {
+        if (statusId == null) {
+            return false;
+        }
+        return statusId != 1 && statusId != 2;
+    }
+
+    private boolean areAllJudgeResultsFinal(JudgeBatchResultDTO batchResult) {
+        if (batchResult == null || batchResult.getSubmissions() == null || batchResult.getSubmissions().isEmpty()) {
+            return false;
+        }
+
+        return batchResult.getSubmissions().stream()
+                .allMatch(result -> result.getStatus() != null
+                        && isFinalJudgeStatus(result.getStatus().getId()));
+    }
+
+    private JudgeBatchResultDTO pollJudgeResults(List<String> tokens) {
+        JudgeBatchResultDTO latestResult = null;
+
+        for (int attempt = 1; attempt <= MAX_RESULT_CHECKS; attempt++) {
+            latestResult = judgeService.getBatchSubmissionResults(tokens);
+
+            if (areAllJudgeResultsFinal(latestResult)) {
+                return latestResult;
+            }
+
+            if (attempt < MAX_RESULT_CHECKS) {
+                try {
+                    Thread.sleep(RESULT_CHECK_DELAY_MS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new IllegalStateException("Judge polling was interrupted", e);
+                }
+            }
+        }
+
+        return latestResult;
+    }
+
+    private Verdict mapJudgeStatusToVerdict(Integer statusId) {
+        if (statusId == null) {
+            return Verdict.INTERNAL_ERROR;
+        }
+
+        if (statusId == 1 || statusId == 2) {
+            return Verdict.PENDING;
+        } else if (statusId == 3) {
+            return Verdict.CORRECT_ANSWER;
+        } else if (statusId == 4) {
+            return Verdict.WRONG_ANSWER;
+        } else if (statusId == 5) {
+            return Verdict.TIME_LIMIT_EXCEEDED;
+        } else if (statusId == 6) {
+            return Verdict.COMPILE_ERROR;
+        } else {
+            return Verdict.INTERNAL_ERROR;
+        }
+    }
+
+    private Verdict aggregateVerdict(JudgeBatchResultDTO batchResult) {
+        if (batchResult == null || batchResult.getSubmissions() == null || batchResult.getSubmissions().isEmpty()) {
+            return Verdict.INTERNAL_ERROR;
+        }
+
+        List<Verdict> verdicts = batchResult.getSubmissions().stream()
+                .map(result -> {
+                    if (result.getStatus() == null) {
+                        return Verdict.INTERNAL_ERROR;
+                    }
+                    return mapJudgeStatusToVerdict(result.getStatus().getId());
+                })
+                .toList();
+
+        if (verdicts.contains(Verdict.COMPILE_ERROR)) {
+            return Verdict.COMPILE_ERROR;
+        }
+
+        if (verdicts.contains(Verdict.TIME_LIMIT_EXCEEDED)) {
+            return Verdict.TIME_LIMIT_EXCEEDED;
+        }
+
+        if (verdicts.contains(Verdict.INTERNAL_ERROR)) {
+            return Verdict.INTERNAL_ERROR;
+        }
+
+        if (verdicts.contains(Verdict.WRONG_ANSWER)) {
+            return Verdict.WRONG_ANSWER;
+        }
+
+        if (verdicts.stream().allMatch(verdict -> verdict == Verdict.CORRECT_ANSWER)) {
+            return Verdict.CORRECT_ANSWER;
+        }
+
+        return Verdict.PENDING;
+    }
+
+    private List<String> extractJudgeTokens(Submission submission) {
+        if (submission == null || submission.getJudgeTokensJson() == null || submission.getJudgeTokensJson().isBlank()) {
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Submission has no stored Judge0 tokens");
+        }
+
+        try {
+            List<JudgeTokenDTO> judgeTokens = objectMapper.readValue(
+                    submission.getJudgeTokensJson(),
+                    objectMapper.getTypeFactory().constructCollectionType(List.class, JudgeTokenDTO.class)
+            );
+
+            return judgeTokens.stream()
+                    .map(JudgeTokenDTO::getJudgeToken)
+                    .toList();
+        } catch (Exception e) {
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to deserialize stored Judge0 tokens");
+        }
+    }
+
+    private Submission refreshSubmissionIfNeeded(Submission submission) {
+        if (submission == null) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Submission not found");
+        }
+
+        if (submission.getStatus() == SubmissionStatus.FINISHED || submission.getStatus() == SubmissionStatus.FAILED) {
+            return submission;
+        }
+
+        List<String> judgeTokens = extractJudgeTokens(submission);
+        JudgeBatchResultDTO batchResult = judgeService.getBatchSubmissionResults(judgeTokens);
+
+        if (areAllJudgeResultsFinal(batchResult)) {
+            submission.setStatus(SubmissionStatus.FINISHED);
+            submission.setVerdict(aggregateVerdict(batchResult));
+        } else {
+            submission.setStatus(SubmissionStatus.RUNNING);
+            submission.setVerdict(Verdict.PENDING);
+        }
+
+        submissionRepository.save(submission);
+        submissionRepository.flush();
+
+        return submission;
+    }
+
+    public CodeRunDTO getLatestRunResult(Long gameSessionId, Long problemId, Long playerSessionId) {
+        if (gameSessionId == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Game session ID is required");
+        }
+        if (problemId == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Problem ID is required");
+        }
+        if (playerSessionId == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Player session ID is required");
+        }
+
+        Submission submission = submissionRepository
+                .findTopByGameSessionIdAndProblemIdAndPlayerSessionIdAndTypeOrderBySubmissionIdDesc(
+                        gameSessionId,
+                        problemId,
+                        playerSessionId,
+                        SubmissionType.RUN
+                );
+        if (submission == null) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "No run submission found");
+        }
+
+        submission = refreshSubmissionIfNeeded(submission);
+
+        CodeRunDTO response = new CodeRunDTO();
+        response.setGameSessionId(gameSessionId);
+        response.setProblemId(problemId);
+        response.setPlayerSessionId(playerSessionId);
+        response.setSubmissionStatus(submission.getStatus());
+        response.setVerdict(submission.getVerdict());
+
+        return response;
+    }
+
+    public CodeSubmissionDTO getLatestSubmissionResult(Long gameSessionId, Long problemId, Long playerSessionId) {
+        if (gameSessionId == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Game session ID is required");
+        }
+        if (problemId == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Problem ID is required");
+        }
+        if (playerSessionId == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Player session ID is required");
+        }
+
+        Submission submission = submissionRepository
+                .findTopByGameSessionIdAndProblemIdAndPlayerSessionIdAndTypeOrderBySubmissionIdDesc(
+                        gameSessionId,
+                        problemId,
+                        playerSessionId,
+                        SubmissionType.SUBMIT
+                );
+        if (submission == null) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "No final submission found");
+        }
+
+        submission = refreshSubmissionIfNeeded(submission);
+
+        CodeSubmissionDTO response = new CodeSubmissionDTO();
+        response.setGameSessionId(gameSessionId);
+        response.setProblemId(problemId);
+        response.setPlayerSessionId(playerSessionId);
+        response.setSubmissionStatus(submission.getStatus());
+        response.setVerdict(submission.getVerdict());
+
+        return response;
+    }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/JudgeService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/JudgeService.java
@@ -36,37 +36,46 @@ public class JudgeService {
     }
 
     public List<JudgeTokenDTO> submitBatch(JudgeBatchRequestDTO batchRequest) {
-    try {
-        String clientId = secretManagerService.getSecret("CF-Access-Client-Id");
-        String clientSecret = secretManagerService.getSecret("CF-Access-Client-Secret");
+        try {
+            String clientId = secretManagerService.getSecret("CF-Access-Client-Id");
+            String clientSecret = secretManagerService.getSecret("CF-Access-Client-Secret");
+            System.out.println("Client ID loaded: " + (clientId != null && !clientId.isBlank()));
+            System.out.println("Client Secret loaded: " + (clientSecret != null && !clientSecret.isBlank()));
+            System.out.println("Client ID length: " + (clientId == null ? 0 : clientId.length()));
+            System.out.println("Client Secret length: " + (clientSecret == null ? 0 : clientSecret.length()));
 
-        String url = judgeApiUrl + "/submissions/batch?base64_encoded=false&wait=false";
+            String url = judgeApiUrl + "/submissions/batch?base64_encoded=false";
 
-        // Serialize manually because it did not work before and I could not figure out why
-        ObjectMapper mapper = new ObjectMapper();
-        String jsonBody = mapper.writeValueAsString(batchRequest);
+            ObjectMapper mapper = new ObjectMapper();
+            String jsonBody = mapper.writeValueAsString(batchRequest);
 
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_JSON);
-        headers.set("CF-Access-Client-Id", clientId);
-        headers.set("CF-Access-Client-Secret", clientSecret);
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            headers.set("CF-Access-Client-Id", clientId);
+            headers.set("CF-Access-Client-Secret", clientSecret);
 
-        // Send as String instead of DTO again I dont know why but this is the only solution I found
-        HttpEntity<String> requestEntity = new HttpEntity<>(jsonBody, headers);
+            HttpEntity<String> requestEntity = new HttpEntity<>(jsonBody, headers);
 
-        ResponseEntity<List<JudgeTokenDTO>> response = restTemplate.exchange(
-                url,
-                HttpMethod.POST,
-                requestEntity,
-                new ParameterizedTypeReference<List<JudgeTokenDTO>>() {}
-        );
+            ResponseEntity<String> response = restTemplate.exchange(
+                    url,
+                    HttpMethod.POST,
+                    requestEntity,
+                    String.class
+            );
 
-        return response.getBody();
+            throw new IllegalStateException(
+                    "Judge0 batch submit debug | status="
+                            + response.getStatusCode()
+                            + " | headers="
+                            + response.getHeaders()
+                            + " | body="
+                            + response.getBody()
+            );
+        }
+        catch (Exception e) {
+            throw new IllegalStateException("Failed to submit batch to Judge API: " + e.getMessage(), e);
+        }
     }
-    catch (Exception e) {
-        throw new IllegalStateException("Failed to submit batch to Judge API: " + e.getMessage(), e); // because globalerror handler gives unuseful info
-    }
-}
 
     public JudgeBatchResultDTO getBatchSubmissionResults(List<String> tokens) {
         if (tokens == null || tokens.isEmpty()) {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/JudgeService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/JudgeService.java
@@ -6,13 +6,16 @@ import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.server.ResponseStatusException;
 
 import ch.uzh.ifi.hase.soprafs26.rest.dto.JudgeBatchRequestDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.JudgeBatchResultDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.JudgeTokenDTO;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -64,5 +67,43 @@ public class JudgeService {
         throw new IllegalStateException("Failed to submit batch to Judge API: " + e.getMessage(), e); // because globalerror handler gives unuseful info
     }
 }
+
+    public JudgeBatchResultDTO getBatchSubmissionResults(List<String> tokens) {
+        if (tokens == null || tokens.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "No judge0 tokens provided");
+        }
+        
+        try {
+    
+
+            String url = judgeApiUrl + "/submissions/batch?tokens=" + String.join(",", tokens) + "&base64_encoded=false";
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.set("CF-Access-Client-Id", secretManagerService.getSecret("CF-Access-Client-Id"));
+            headers.set("CF-Access-Client-Secret", secretManagerService.getSecret("CF-Access-Client-Secret"));
+            headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+
+            // For get the body is empty so we can use Void
+            HttpEntity<Void> requestEntity = new HttpEntity<>(headers);
+
+            ResponseEntity<JudgeBatchResultDTO> response = restTemplate.exchange(
+                    url,
+                    HttpMethod.GET,
+                    requestEntity,
+                    JudgeBatchResultDTO.class
+            );
+
+
+            JudgeBatchResultDTO body = response.getBody();
+            if (body == null) {
+                throw new IllegalStateException("Judge API returned an empty response body");
+            }
+            return body;
+            
+        }
+        catch (Exception e) {
+            throw new IllegalStateException("Failed to get batch submission results from Judge API: " + e.getMessage(), e); // because globalerror handler gives unuseful info
+        }
+    }
 
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/JudgeService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/JudgeService.java
@@ -28,16 +28,19 @@ public class JudgeService {
 
     private final Logger log = LoggerFactory.getLogger(JudgeService.class);
 
-    @Value("${CF_Access_Client_Id}")
-    private String cfClientId;
-
-    @Value("${CF_Access_Client_Secret}")
-    private String cfClientSecret;
-
+    private final String cfClientId;
+    private final String cfClientSecret;
     private final RestTemplate restTemplate;
     private final ObjectMapper objectMapper;
 
-    public JudgeService() {
+    // Added a colon (:) after the property names to provide an empty default value.
+    // This prevents Spring context from crashing during Gradle tests when the env vars are missing.
+    public JudgeService(
+            @Value("${CF_Access_Client_Id:}") String cfClientId,
+            @Value("${CF_Access_Client_Secret:}") String cfClientSecret
+    ) {
+        this.cfClientId = cfClientId != null ? cfClientId.trim() : "";
+        this.cfClientSecret = cfClientSecret != null ? cfClientSecret.trim() : "";
         this.restTemplate = new RestTemplate();
         this.objectMapper = new ObjectMapper();
     }
@@ -48,9 +51,8 @@ public class JudgeService {
     private HttpHeaders createHeaders() {
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
-        // .trim() removes any accidental spaces, \n, or \r hidden in the text file
-        headers.set("CF-Access-Client-Id", cfClientId != null ? cfClientId.trim() : "");
-        headers.set("CF-Access-Client-Secret", cfClientSecret != null ? cfClientSecret.trim() : "");
+        headers.set("CF-Access-Client-Id", cfClientId);
+        headers.set("CF-Access-Client-Secret", cfClientSecret);
         return headers;
     }
 
@@ -61,13 +63,12 @@ public class JudgeService {
         String judge0Url = "https://judge.hamcoh.com/submissions/batch?base64_encoded=false";
 
         try {
-            // 1. Force the Java object into a perfect JSON String
+            // Force the Java object into a perfect JSON String
             String jsonBody = objectMapper.writeValueAsString(requestPayload);
             
-            // 2. Log it to the terminal so we can see exactly what is being sent
             log.info("Sending JSON Payload to Judge0: {}", jsonBody);
 
-            // 3. Attach the raw JSON string to our Request Entity
+            // Attach the raw JSON string to our Request Entity
             HttpEntity<String> entity = new HttpEntity<>(jsonBody, createHeaders());
 
             log.info("Sending batch submission to Judge0...");
@@ -90,7 +91,6 @@ public class JudgeService {
             
             throw new ResponseStatusException(
                     HttpStatus.valueOf(statusCode), 
-                    // We append the raw Judge0 error so Postman tells us exactly what went wrong
                     "Error communicating with Judge0 API: " + e.getResponseBodyAsString() 
             );
         } catch (Exception e) {
@@ -106,7 +106,7 @@ public class JudgeService {
      * GET: Fetches the results for a list of submission tokens.
      */
     public JudgeBatchResultDTO getBatchSubmissionResults(List<String> tokens) {
-        // Judge0 expects tokens comma-separated in the URL: ?tokens=token1,token2,token3
+        // Judge0 expects tokens comma-separated in the URL
         String joinedTokens = String.join(",", tokens);
         String judge0Url = "https://judge.hamcoh.com/submissions/batch?tokens=" + joinedTokens + "&base64_encoded=false";
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/JudgeService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/JudgeService.java
@@ -1,7 +1,12 @@
 package ch.uzh.ifi.hase.soprafs26.service;
 
-import java.util.List;
-
+import ch.uzh.ifi.hase.soprafs26.rest.dto.JudgeBatchRequestDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.JudgeBatchResultDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.JudgeTokenDTO;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -10,109 +15,130 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestClientResponseException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.server.ResponseStatusException;
 
-import ch.uzh.ifi.hase.soprafs26.rest.dto.JudgeBatchRequestDTO;
-import ch.uzh.ifi.hase.soprafs26.rest.dto.JudgeBatchResultDTO;
-import ch.uzh.ifi.hase.soprafs26.rest.dto.JudgeTokenDTO;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-
+import java.util.List;
 
 @Service
+@Transactional
 public class JudgeService {
 
+    private final Logger log = LoggerFactory.getLogger(JudgeService.class);
+
+    @Value("${CF_Access_Client_Id}")
+    private String cfClientId;
+
+    @Value("${CF_Access_Client_Secret}")
+    private String cfClientSecret;
+
     private final RestTemplate restTemplate;
-    private final SecretManagerService secretManagerService;
+    private final ObjectMapper objectMapper;
 
-    @Value("${judge0.api.url}")
-    private String judgeApiUrl;
-
-    public JudgeService(RestTemplate restTemplate, SecretManagerService secretManagerService) {
-        this.restTemplate = restTemplate;
-        this.secretManagerService = secretManagerService;
+    public JudgeService() {
+        this.restTemplate = new RestTemplate();
+        this.objectMapper = new ObjectMapper();
     }
 
-    public List<JudgeTokenDTO> submitBatch(JudgeBatchRequestDTO batchRequest) {
+    /**
+     * Helper method to attach Cloudflare Access tokens to every request
+     */
+    private HttpHeaders createHeaders() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        // .trim() removes any accidental spaces, \n, or \r hidden in the text file
+        headers.set("CF-Access-Client-Id", cfClientId != null ? cfClientId.trim() : "");
+        headers.set("CF-Access-Client-Secret", cfClientSecret != null ? cfClientSecret.trim() : "");
+        return headers;
+    }
+
+    /**
+     * POST: Submits a batch of code to the Judge0 API protected by Cloudflare.
+     */
+    public List<JudgeTokenDTO> submitBatch(JudgeBatchRequestDTO requestPayload) {
+        String judge0Url = "https://judge.hamcoh.com/submissions/batch?base64_encoded=false";
+
         try {
-            String clientId = secretManagerService.getSecret("CF-Access-Client-Id");
-            String clientSecret = secretManagerService.getSecret("CF-Access-Client-Secret");
-            System.out.println("Client ID loaded: " + (clientId != null && !clientId.isBlank()));
-            System.out.println("Client Secret loaded: " + (clientSecret != null && !clientSecret.isBlank()));
-            System.out.println("Client ID length: " + (clientId == null ? 0 : clientId.length()));
-            System.out.println("Client Secret length: " + (clientSecret == null ? 0 : clientSecret.length()));
+            // 1. Force the Java object into a perfect JSON String
+            String jsonBody = objectMapper.writeValueAsString(requestPayload);
+            
+            // 2. Log it to the terminal so we can see exactly what is being sent
+            log.info("Sending JSON Payload to Judge0: {}", jsonBody);
 
-            String url = judgeApiUrl + "/submissions/batch?base64_encoded=false";
+            // 3. Attach the raw JSON string to our Request Entity
+            HttpEntity<String> entity = new HttpEntity<>(jsonBody, createHeaders());
 
-            ObjectMapper mapper = new ObjectMapper();
-            String jsonBody = mapper.writeValueAsString(batchRequest);
-
-            HttpHeaders headers = new HttpHeaders();
-            headers.setContentType(MediaType.APPLICATION_JSON);
-            headers.set("CF-Access-Client-Id", clientId);
-            headers.set("CF-Access-Client-Secret", clientSecret);
-
-            HttpEntity<String> requestEntity = new HttpEntity<>(jsonBody, headers);
-
-            ResponseEntity<String> response = restTemplate.exchange(
-                    url,
+            log.info("Sending batch submission to Judge0...");
+            
+            // Using ParameterizedTypeReference because Judge0 returns a JSON Array of tokens
+            ResponseEntity<List<JudgeTokenDTO>> response = restTemplate.exchange(
+                    judge0Url,
                     HttpMethod.POST,
-                    requestEntity,
-                    String.class
+                    entity,
+                    new ParameterizedTypeReference<List<JudgeTokenDTO>>() {}
             );
+            
+            log.info("Successfully submitted batch. Status: {}", response.getStatusCode().value());
+            return response.getBody();
 
-            throw new IllegalStateException(
-                    "Judge0 batch submit debug | status="
-                            + response.getStatusCode()
-                            + " | headers="
-                            + response.getHeaders()
-                            + " | body="
-                            + response.getBody()
+        } catch (RestClientResponseException e) {
+            int statusCode = e.getStatusCode().value();
+            log.error("Failed to submit batch to Judge API. Status: {} | Response: {}", 
+                      statusCode, e.getResponseBodyAsString());
+            
+            throw new ResponseStatusException(
+                    HttpStatus.valueOf(statusCode), 
+                    // We append the raw Judge0 error so Postman tells us exactly what went wrong
+                    "Error communicating with Judge0 API: " + e.getResponseBodyAsString() 
             );
-        }
-        catch (Exception e) {
-            throw new IllegalStateException("Failed to submit batch to Judge API: " + e.getMessage(), e);
+        } catch (Exception e) {
+            log.error("Unexpected error during Judge0 API call", e);
+            throw new ResponseStatusException(
+                    HttpStatus.INTERNAL_SERVER_ERROR, 
+                    "Internal error while contacting the Judge API."
+            );
         }
     }
 
+    /**
+     * GET: Fetches the results for a list of submission tokens.
+     */
     public JudgeBatchResultDTO getBatchSubmissionResults(List<String> tokens) {
-        if (tokens == null || tokens.isEmpty()) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "No judge0 tokens provided");
-        }
-        
+        // Judge0 expects tokens comma-separated in the URL: ?tokens=token1,token2,token3
+        String joinedTokens = String.join(",", tokens);
+        String judge0Url = "https://judge.hamcoh.com/submissions/batch?tokens=" + joinedTokens + "&base64_encoded=false";
+
+        // GET requests don't have a body, just headers
+        HttpEntity<Void> entity = new HttpEntity<>(createHeaders());
+
         try {
-    
-
-            String url = judgeApiUrl + "/submissions/batch?tokens=" + String.join(",", tokens) + "&base64_encoded=false";
-
-            HttpHeaders headers = new HttpHeaders();
-            headers.set("CF-Access-Client-Id", secretManagerService.getSecret("CF-Access-Client-Id"));
-            headers.set("CF-Access-Client-Secret", secretManagerService.getSecret("CF-Access-Client-Secret"));
-            headers.setAccept(List.of(MediaType.APPLICATION_JSON));
-
-            // For get the body is empty so we can use Void
-            HttpEntity<Void> requestEntity = new HttpEntity<>(headers);
-
+            log.info("Polling Judge0 for batch results...");
             ResponseEntity<JudgeBatchResultDTO> response = restTemplate.exchange(
-                    url,
+                    judge0Url,
                     HttpMethod.GET,
-                    requestEntity,
+                    entity,
                     JudgeBatchResultDTO.class
             );
 
+            return response.getBody();
 
-            JudgeBatchResultDTO body = response.getBody();
-            if (body == null) {
-                throw new IllegalStateException("Judge API returned an empty response body");
-            }
-            return body;
+        } catch (RestClientResponseException e) {
+            int statusCode = e.getStatusCode().value();
+            log.error("Failed to fetch batch results. Status: {} | Response: {}", 
+                      statusCode, e.getResponseBodyAsString());
             
-        }
-        catch (Exception e) {
-            throw new IllegalStateException("Failed to get batch submission results from Judge API: " + e.getMessage(), e); // because globalerror handler gives unuseful info
+            throw new ResponseStatusException(
+                    HttpStatus.valueOf(statusCode), 
+                    "Error fetching results from Judge0 API: " + e.getMessage()
+            );
+        } catch (Exception e) {
+            log.error("Unexpected error fetching Judge0 results", e);
+            throw new ResponseStatusException(
+                    HttpStatus.INTERNAL_SERVER_ERROR, 
+                    "Internal error while fetching results."
+            );
         }
     }
-
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SecretManagerService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SecretManagerService.java
@@ -9,10 +9,30 @@ import org.springframework.stereotype.Service;
 @Service
 public class SecretManagerService {
 
-    @Value("${gcp.project-id}")
+    @Value("${gcp.project-id:}")
     private String projectId;
 
     public String getSecret(String secretId) {
+        // 1) Local development fallback: environment variables only
+        String envValue = System.getenv(secretId);
+
+        // Support shell-friendly names like CF_Access_Client_Id
+        if (envValue == null || envValue.isBlank()) {
+            String normalizedEnvName = secretId.replace('-', '_');
+            envValue = System.getenv(normalizedEnvName);
+        }
+
+        if (envValue != null && !envValue.isBlank()) {
+            return envValue;
+        }
+
+        // 2) Deployment fallback: Google Secret Manager
+        if (projectId == null || projectId.isBlank()) {
+            throw new IllegalStateException(
+                    "Missing GCP project id and no local environment variable found for secret: " + secretId
+            );
+        }
+
         SecretVersionName secretVersionName =
                 SecretVersionName.of(projectId, secretId, "latest");
 

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/CodeExecutionControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/CodeExecutionControllerTest.java
@@ -37,7 +37,7 @@ class CodeExecutionControllerTest {
 
         when(codeExecutionService.runCode(eq(1L), eq(2L), any())).thenReturn(response);
 
-        mockMvc.perform(post("/games/1/problems/2/run")
+        mockMvc.perform(post("/games/1/problems/2/runs")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
                                 {
@@ -63,7 +63,7 @@ class CodeExecutionControllerTest {
 
         when(codeExecutionService.submitCode(eq(1L), eq(2L), any())).thenReturn(response);
 
-        mockMvc.perform(post("/games/1/problems/2/submission")
+        mockMvc.perform(post("/games/1/problems/2/submissions")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
                                 {

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/CodeExecutionControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/CodeExecutionControllerTest.java
@@ -37,7 +37,7 @@ class CodeExecutionControllerTest {
 
         when(codeExecutionService.runCode(eq(1L), eq(2L), any())).thenReturn(response);
 
-        mockMvc.perform(post("/games/1/problems/2/runs")
+        mockMvc.perform(post("/games/1/problems/2/run")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
                                 {
@@ -63,7 +63,7 @@ class CodeExecutionControllerTest {
 
         when(codeExecutionService.submitCode(eq(1L), eq(2L), any())).thenReturn(response);
 
-        mockMvc.perform(post("/games/1/problems/2/submissions")
+        mockMvc.perform(post("/games/1/problems/2/submission")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
                                 {

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/CodeExecutionServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/CodeExecutionServiceTest.java
@@ -118,7 +118,7 @@ class CodeExecutionServiceTest {
         assertEquals(problemId, finalSavedSubmission.getProblemId());
         assertEquals(playerSessionId, finalSavedSubmission.getPlayerSessionId());
         assertEquals(SubmissionType.RUN, finalSavedSubmission.getType());
-        assertEquals(0, finalSavedSubmission.getPassedTestCases());
+        assertEquals(2, finalSavedSubmission.getPassedTestCases());
         assertEquals(2, finalSavedSubmission.getTotalTestCases());
         assertEquals(SubmissionStatus.FINISHED, finalSavedSubmission.getStatus());
         assertEquals(Verdict.CORRECT_ANSWER, finalSavedSubmission.getVerdict());
@@ -189,4 +189,193 @@ class CodeExecutionServiceTest {
         verify(judgeService, never()).submitBatch(any());
         verify(submissionRepository, never()).save(any());
     }
+
+    @Test
+    void runCode_wrongAnswer_returnsFinishedAndWrongAnswerVerdict() {
+        Long gameSessionId = 1L;
+        Long problemId = 2L;
+        Long playerSessionId = 3L;
+
+        CodeExecutionPostDTO request = new CodeExecutionPostDTO();
+        request.setPlayerSessionId(playerSessionId);
+        request.setSourceCode("def solution(input_data):\n    return input_data");
+
+        TestCase tc = new TestCase();
+        tc.setInput("abc");
+        tc.setExpectedOutput("cba");
+
+        Problem problem = new Problem();
+        problem.setProblemId(problemId);
+        problem.setGameLanguage(GameLanguage.PYTHON);
+        problem.setGameDifficulty(GameDifficulty.EASY);
+        problem.setTestCases(List.of(tc));
+
+        JudgeTokenDTO token = new JudgeTokenDTO();
+        token.setJudgeToken("tok1");
+
+        JudgeStatusDTO wrongAnswerStatus = new JudgeStatusDTO();
+        wrongAnswerStatus.setId(4);
+        wrongAnswerStatus.setDescription("Wrong Answer");
+
+        JudgeResultDTO result1 = new JudgeResultDTO();
+        result1.setToken("tok1");
+        result1.setStatus(wrongAnswerStatus);
+
+        JudgeBatchResultDTO batchResult = new JudgeBatchResultDTO();
+        batchResult.setSubmissions(List.of(result1));
+
+        when(problemService.getProblemById(problemId)).thenReturn(problem);
+        when(judgeService.submitBatch(any())).thenReturn(List.of(token));
+        when(judgeService.getBatchSubmissionResults(anyList())).thenReturn(batchResult);
+        when(submissionRepository.save(any(Submission.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        CodeRunDTO result = codeExecutionService.runCode(gameSessionId, problemId, request);
+
+        assertEquals(SubmissionStatus.FINISHED, result.getSubmissionStatus());
+        assertEquals(Verdict.WRONG_ANSWER, result.getVerdict());
+        assertEquals(0, result.getPassedTestCases());
+        assertEquals(1, result.getTotalTestCases());
+    }
+
+    @Test
+    void runCode_compileError_returnsFinishedAndCompileErrorVerdict() {
+        Long gameSessionId = 1L;
+        Long problemId = 2L;
+        Long playerSessionId = 3L;
+
+        CodeExecutionPostDTO request = new CodeExecutionPostDTO();
+        request.setPlayerSessionId(playerSessionId);
+        request.setSourceCode("def solution(input_data)\n    return input_data");
+
+        TestCase tc = new TestCase();
+        tc.setInput("abc");
+        tc.setExpectedOutput("abc");
+
+        Problem problem = new Problem();
+        problem.setProblemId(problemId);
+        problem.setGameLanguage(GameLanguage.PYTHON);
+        problem.setGameDifficulty(GameDifficulty.EASY);
+        problem.setTestCases(List.of(tc));
+
+        JudgeTokenDTO token = new JudgeTokenDTO();
+        token.setJudgeToken("tok1");
+
+        JudgeStatusDTO compileStatus = new JudgeStatusDTO();
+        compileStatus.setId(6);
+        compileStatus.setDescription("Compilation Error");
+
+        JudgeResultDTO result1 = new JudgeResultDTO();
+        result1.setToken("tok1");
+        result1.setStatus(compileStatus);
+
+        JudgeBatchResultDTO batchResult = new JudgeBatchResultDTO();
+        batchResult.setSubmissions(List.of(result1));
+
+        when(problemService.getProblemById(problemId)).thenReturn(problem);
+        when(judgeService.submitBatch(any())).thenReturn(List.of(token));
+        when(judgeService.getBatchSubmissionResults(anyList())).thenReturn(batchResult);
+        when(submissionRepository.save(any(Submission.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        CodeRunDTO result = codeExecutionService.runCode(gameSessionId, problemId, request);
+
+        assertEquals(SubmissionStatus.FINISHED, result.getSubmissionStatus());
+        assertEquals(Verdict.COMPILE_ERROR, result.getVerdict());
+    }
+
+    @Test
+    void runCode_timeLimitExceeded_returnsFinishedAndTimeLimitVerdict() {
+        Long gameSessionId = 1L;
+        Long problemId = 2L;
+        Long playerSessionId = 3L;
+
+        CodeExecutionPostDTO request = new CodeExecutionPostDTO();
+        request.setPlayerSessionId(playerSessionId);
+        request.setSourceCode("def solution(input_data):\n    while True:\n        pass");
+
+        TestCase tc = new TestCase();
+        tc.setInput("abc");
+        tc.setExpectedOutput("abc");
+
+        Problem problem = new Problem();
+        problem.setProblemId(problemId);
+        problem.setGameLanguage(GameLanguage.PYTHON);
+        problem.setGameDifficulty(GameDifficulty.EASY);
+        problem.setTestCases(List.of(tc));
+
+        JudgeTokenDTO token = new JudgeTokenDTO();
+        token.setJudgeToken("tok1");
+
+        JudgeStatusDTO tleStatus = new JudgeStatusDTO();
+        tleStatus.setId(5);
+        tleStatus.setDescription("Time Limit Exceeded");
+
+        JudgeResultDTO result1 = new JudgeResultDTO();
+        result1.setToken("tok1");
+        result1.setStatus(tleStatus);
+
+        JudgeBatchResultDTO batchResult = new JudgeBatchResultDTO();
+        batchResult.setSubmissions(List.of(result1));
+
+        when(problemService.getProblemById(problemId)).thenReturn(problem);
+        when(judgeService.submitBatch(any())).thenReturn(List.of(token));
+        when(judgeService.getBatchSubmissionResults(anyList())).thenReturn(batchResult);
+        when(submissionRepository.save(any(Submission.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        CodeRunDTO result = codeExecutionService.runCode(gameSessionId, problemId, request);
+
+        assertEquals(SubmissionStatus.FINISHED, result.getSubmissionStatus());
+        assertEquals(Verdict.TIME_LIMIT_EXCEEDED, result.getVerdict());
+    }
+
+    /**
+     *  when we run the code we have a time limit for how long we wait 
+     * for the judge result. The user should then get a "running" status and 
+     * a "pending" verdict, which indicates that the code is still being judged.
+    */
+    @Test
+    void runCode_processingAfterPollingWindow_returnsRunningAndPendingVerdict() {
+        Long gameSessionId = 1L;
+        Long problemId = 2L;
+        Long playerSessionId = 3L;
+
+        CodeExecutionPostDTO request = new CodeExecutionPostDTO();
+        request.setPlayerSessionId(playerSessionId);
+        request.setSourceCode("def solution(input_data):\n    return input_data");
+
+        TestCase tc = new TestCase();
+        tc.setInput("abc");
+        tc.setExpectedOutput("abc");
+
+        Problem problem = new Problem();
+        problem.setProblemId(problemId);
+        problem.setGameLanguage(GameLanguage.PYTHON);
+        problem.setGameDifficulty(GameDifficulty.EASY);
+        problem.setTestCases(List.of(tc));
+
+        JudgeTokenDTO token = new JudgeTokenDTO();
+        token.setJudgeToken("tok1");
+
+        JudgeStatusDTO processingStatus = new JudgeStatusDTO();
+        processingStatus.setId(2);
+        processingStatus.setDescription("Processing");
+
+        JudgeResultDTO result1 = new JudgeResultDTO();
+        result1.setToken("tok1");
+        result1.setStatus(processingStatus);
+
+        JudgeBatchResultDTO batchResult = new JudgeBatchResultDTO();
+        batchResult.setSubmissions(List.of(result1));
+
+        when(problemService.getProblemById(problemId)).thenReturn(problem);
+        when(judgeService.submitBatch(any())).thenReturn(List.of(token));
+        when(judgeService.getBatchSubmissionResults(anyList()))
+                .thenReturn(batchResult, batchResult, batchResult);
+        when(submissionRepository.save(any(Submission.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        CodeRunDTO result = codeExecutionService.runCode(gameSessionId, problemId, request);
+
+        assertEquals(SubmissionStatus.RUNNING, result.getSubmissionStatus());
+        assertEquals(Verdict.PENDING, result.getVerdict());
+    }
+
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/CodeExecutionServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/CodeExecutionServiceTest.java
@@ -59,7 +59,8 @@ class CodeExecutionServiceTest {
 
         CodeExecutionPostDTO request = new CodeExecutionPostDTO();
         request.setPlayerSessionId(playerSessionId);
-        request.setSourceCode("def solution(input_data):\n    return input_data[::-1]");
+        // Updated to use "def solve" and "return"
+        request.setSourceCode("def solve(input_data):\n    return input_data[::-1]");
 
         TestCase tc1 = new TestCase();
         tc1.setInput("hello");
@@ -133,7 +134,8 @@ class CodeExecutionServiceTest {
 
         CodeExecutionPostDTO request = new CodeExecutionPostDTO();
         request.setPlayerSessionId(playerSessionId);
-        request.setSourceCode("print('hello')");
+        // Updated to use "def solve" and "return"
+        request.setSourceCode("def solve(x):\n    return x");
 
         when(submissionRepository.existsByGameSessionIdAndProblemIdAndPlayerSessionIdAndType(
                 gameSessionId, problemId, playerSessionId, SubmissionType.SUBMIT
@@ -171,7 +173,8 @@ class CodeExecutionServiceTest {
     void runCode_problemWithoutTestCases_throwsBadRequest() {
         CodeExecutionPostDTO request = new CodeExecutionPostDTO();
         request.setPlayerSessionId(3L);
-        request.setSourceCode("def solution(input_data):\n    return input_data");
+        // Updated to use "def solve" and "return"
+        request.setSourceCode("def solve(input_data):\n    return input_data");
 
         Problem problem = new Problem();
         problem.setProblemId(2L);
@@ -198,7 +201,8 @@ class CodeExecutionServiceTest {
 
         CodeExecutionPostDTO request = new CodeExecutionPostDTO();
         request.setPlayerSessionId(playerSessionId);
-        request.setSourceCode("def solution(input_data):\n    return input_data");
+        // Updated to use "def solve" and "return"
+        request.setSourceCode("def solve(input_data):\n    return input_data");
 
         TestCase tc = new TestCase();
         tc.setInput("abc");
@@ -245,7 +249,8 @@ class CodeExecutionServiceTest {
 
         CodeExecutionPostDTO request = new CodeExecutionPostDTO();
         request.setPlayerSessionId(playerSessionId);
-        request.setSourceCode("def solution(input_data)\n    return input_data");
+        // Updated to use "def solve" and "return"
+        request.setSourceCode("def solve(input_data)\n    return input_data");
 
         TestCase tc = new TestCase();
         tc.setInput("abc");
@@ -290,7 +295,8 @@ class CodeExecutionServiceTest {
 
         CodeExecutionPostDTO request = new CodeExecutionPostDTO();
         request.setPlayerSessionId(playerSessionId);
-        request.setSourceCode("def solution(input_data):\n    while True:\n        pass");
+        // Updated to use "def solve" and "return"
+        request.setSourceCode("def solve(input_data):\n    while True:\n        pass\n    return input_data");
 
         TestCase tc = new TestCase();
         tc.setInput("abc");
@@ -328,7 +334,7 @@ class CodeExecutionServiceTest {
     }
 
     /**
-     *  when we run the code we have a time limit for how long we wait 
+     * when we run the code we have a time limit for how long we wait 
      * for the judge result. The user should then get a "running" status and 
      * a "pending" verdict, which indicates that the code is still being judged.
     */
@@ -340,7 +346,8 @@ class CodeExecutionServiceTest {
 
         CodeExecutionPostDTO request = new CodeExecutionPostDTO();
         request.setPlayerSessionId(playerSessionId);
-        request.setSourceCode("def solution(input_data):\n    return input_data");
+        // Updated to use "def solve" and "return"
+        request.setSourceCode("def solve(input_data):\n    return input_data");
 
         TestCase tc = new TestCase();
         tc.setInput("abc");

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/CodeExecutionServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/CodeExecutionServiceTest.java
@@ -4,12 +4,16 @@ import ch.uzh.ifi.hase.soprafs26.constant.GameDifficulty;
 import ch.uzh.ifi.hase.soprafs26.constant.GameLanguage;
 import ch.uzh.ifi.hase.soprafs26.constant.SubmissionStatus;
 import ch.uzh.ifi.hase.soprafs26.constant.SubmissionType;
+import ch.uzh.ifi.hase.soprafs26.constant.Verdict;
 import ch.uzh.ifi.hase.soprafs26.entity.Problem;
 import ch.uzh.ifi.hase.soprafs26.entity.Submission;
 import ch.uzh.ifi.hase.soprafs26.entity.TestCase;
 import ch.uzh.ifi.hase.soprafs26.repository.SubmissionRepository;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.CodeExecutionPostDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.CodeRunDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.JudgeBatchResultDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.JudgeResultDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.JudgeStatusDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.JudgeTokenDTO;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -20,6 +24,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.*;
 
 class CodeExecutionServiceTest {
@@ -47,7 +52,7 @@ class CodeExecutionServiceTest {
     }
 
     @Test
-    void runCode_validInput_returnsTokensAndSavesSubmission() {
+    void runCode_validInput_returnsFinishedStatusAndVerdict_andSavesSubmission() {
         Long gameSessionId = 1L;
         Long problemId = 2L;
         Long playerSessionId = 3L;
@@ -76,8 +81,24 @@ class CodeExecutionServiceTest {
         JudgeTokenDTO token2 = new JudgeTokenDTO();
         token2.setJudgeToken("tok2");
 
+        JudgeStatusDTO acceptedStatus = new JudgeStatusDTO();
+        acceptedStatus.setId(3);
+        acceptedStatus.setDescription("Accepted");
+
+        JudgeResultDTO result1 = new JudgeResultDTO();
+        result1.setToken("tok1");
+        result1.setStatus(acceptedStatus);
+
+        JudgeResultDTO result2 = new JudgeResultDTO();
+        result2.setToken("tok2");
+        result2.setStatus(acceptedStatus);
+
+        JudgeBatchResultDTO batchResult = new JudgeBatchResultDTO();
+        batchResult.setSubmissions(List.of(result1, result2));
+
         when(problemService.getProblemById(problemId)).thenReturn(problem);
         when(judgeService.submitBatch(any())).thenReturn(List.of(token1, token2));
+        when(judgeService.getBatchSubmissionResults(anyList())).thenReturn(batchResult);
         when(submissionRepository.save(any(Submission.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
         CodeRunDTO result = codeExecutionService.runCode(gameSessionId, problemId, request);
@@ -86,22 +107,22 @@ class CodeExecutionServiceTest {
         assertEquals(gameSessionId, result.getGameSessionId());
         assertEquals(problemId, result.getProblemId());
         assertEquals(playerSessionId, result.getPlayerSessionId());
-        assertEquals(2, result.getTokens().size());
-        assertEquals("tok1", result.getTokens().get(0));
-        assertEquals("tok2", result.getTokens().get(1));
+        assertEquals(SubmissionStatus.FINISHED, result.getSubmissionStatus());
+        assertEquals(Verdict.CORRECT_ANSWER, result.getVerdict());
 
         ArgumentCaptor<Submission> submissionCaptor = ArgumentCaptor.forClass(Submission.class);
-        verify(submissionRepository, times(1)).save(submissionCaptor.capture());
+        verify(submissionRepository, times(2)).save(submissionCaptor.capture());
 
-        Submission savedSubmission = submissionCaptor.getValue();
-        assertEquals(gameSessionId, savedSubmission.getGameSessionId());
-        assertEquals(problemId, savedSubmission.getProblemId());
-        assertEquals(playerSessionId, savedSubmission.getPlayerSessionId());
-        assertEquals(SubmissionType.RUN, savedSubmission.getType());
-        assertEquals(0, savedSubmission.getPassedTestCases());
-        assertEquals(2, savedSubmission.getTotalTestCases());
-        assertEquals(SubmissionStatus.PENDING, savedSubmission.getStatus());
-        assertNotNull(savedSubmission.getJudgeTokensJson());
+        Submission finalSavedSubmission = submissionCaptor.getAllValues().get(1);
+        assertEquals(gameSessionId, finalSavedSubmission.getGameSessionId());
+        assertEquals(problemId, finalSavedSubmission.getProblemId());
+        assertEquals(playerSessionId, finalSavedSubmission.getPlayerSessionId());
+        assertEquals(SubmissionType.RUN, finalSavedSubmission.getType());
+        assertEquals(0, finalSavedSubmission.getPassedTestCases());
+        assertEquals(2, finalSavedSubmission.getTotalTestCases());
+        assertEquals(SubmissionStatus.FINISHED, finalSavedSubmission.getStatus());
+        assertEquals(Verdict.CORRECT_ANSWER, finalSavedSubmission.getVerdict());
+        assertNotNull(finalSavedSubmission.getJudgeTokensJson());
     }
 
     @Test


### PR DESCRIPTION
**How to test in postman:**
1.  To test judge you need to create a file on your pc with the cloudflare secret values. The file should look like this: _export CF_Access_Client_Id=xyz.access_ (line 1)  _export CF_Access_Client_Secret=xyz_ (line 2). 
2.  E.g `localhost:8080/games/1/problems/9/run` with body->raw: `{
  "playerSessionId": 1,
  "sourceCode": "def solve(s):\n    words = s.split()\n    return ' '.join(reversed(words))"
}` The problem_id '9' corresponds to "reverse_sentence" because it's the 9th file.

**What's new:**

- Implemented full Judge0 batch submission flow for both /run and /submission
- Fixed wrapper
- Added Judge0 batch result retrieval by stored submission tokens
- Result handling:
    backend stores a local Submission immediately with PENDING
    backend polls Judge0 up to 3 times with 1 second delay
    if still unfinished, submission remains RUNNING
    frontend can later poll backend result endpoints
- Added backend polling endpoints for retrieving latest execution results:
    GET /games/{gameSessionId}/problems/{problemId}/run-result
    GET /games/{gameSessionId}/problems/{problemId}/submission-result
- Judge successfully return JSON's with info
- Added verdict handling and mapping from Judge0 status codes to internal verdicts e.g all judge-codes > 6 => internal_error
- Implemented aggregation of Judge0 testcase results into a single overall verdict, since it only gives single tokens for one single t
- Added storage and return of testcase progress:
    totalTestCases
    passedTestCases
- Updated CodeRunDTO and CodeSubmissionDTO to return meaningful backend feedback instead of raw Judge0 tokens
- Kept SUBMIT restricted to one final submission per player/problem/session
- Added rate limiting for repeated /run requests to support the 429 Too Many Requests case from the REST spec (to avoid ddos)
- Added helper logic to refresh stored running submissions when result polling endpoints are called
- Added / updated service tests for:
    successful finished run flow
    duplicate final submit conflict
    invalid request handling
    missing testcases
    Judge0 verdict/status behavior

<img width="474" height="186" alt="image" src="https://github.com/user-attachments/assets/bdc213cb-e12c-4c35-af49-5b37a4257d16" />


