### PR TITLE
We now return structured test case feedback to frontend(#104)

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/CodeRunDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/CodeRunDTO.java
@@ -16,6 +16,7 @@ public class CodeRunDTO {
     private String judgeResultsJson;
     private int passedTestCases;
     private int totalTestCases;
+    private List<TestCaseFeedbackDTO> testCases;
 
     public Long getGameSessionId() {
         return gameSessionId;
@@ -89,4 +90,11 @@ public class CodeRunDTO {
         this.totalTestCases = totalTestCases;
     }
 
+    public List<TestCaseFeedbackDTO> getTestCases() {
+        return testCases;
+    }
+
+    public void setTestCases(List<TestCaseFeedbackDTO> testCases) {
+        this.testCases = testCases;
+    }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/CodeSubmissionDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/CodeSubmissionDTO.java
@@ -11,11 +11,11 @@ public class CodeSubmissionDTO {
     private Long problemId;
     private Long playerSessionId;
     private List<String> tokens;
-    private SubmissionStatus submissionStatus;  
+    private SubmissionStatus submissionStatus;
     private Verdict verdict;
-    private String judgeResultsJson;
     private int passedTestCases;
     private int totalTestCases;
+    private List<TestCaseFeedbackDTO> testCases;
 
     public Long getGameSessionId() {
         return gameSessionId;
@@ -65,14 +65,6 @@ public class CodeSubmissionDTO {
         this.verdict = verdict;
     }
 
-    public String getJudgeResultsJson() {
-        return judgeResultsJson;
-    }
-
-    public void setJudgeResultsJson(String judgeResultsJson) {
-        this.judgeResultsJson = judgeResultsJson;
-    }
-
     public int getPassedTestCases() {
         return passedTestCases;
     }
@@ -88,5 +80,12 @@ public class CodeSubmissionDTO {
     public void setTotalTestCases(int totalTestCases) {
         this.totalTestCases = totalTestCases;
     }
-    
+
+    public List<TestCaseFeedbackDTO> getTestCases() {
+        return testCases;
+    }
+
+    public void setTestCases(List<TestCaseFeedbackDTO> testCases) {
+        this.testCases = testCases;
+    }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/TestCaseFeedbackDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/TestCaseFeedbackDTO.java
@@ -1,0 +1,50 @@
+package ch.uzh.ifi.hase.soprafs26.rest.dto;
+
+public class TestCaseFeedbackDTO {
+
+    private Integer testCaseId;
+    private String result;
+    private String actualOutput;
+    private String expectedOutput;
+    private String errorMessage;
+
+    public Integer getTestCaseId() {
+        return testCaseId;
+    }
+
+    public void setTestCaseId(Integer testCaseId) {
+        this.testCaseId = testCaseId;
+    }
+
+    public String getResult() {
+        return result;
+    }
+
+    public void setResult(String result) {
+        this.result = result;
+    }
+
+    public String getActualOutput() {
+        return actualOutput;
+    }
+
+    public void setActualOutput(String actualOutput) {
+        this.actualOutput = actualOutput;
+    }
+
+    public String getExpectedOutput() {
+        return expectedOutput;
+    }
+
+    public void setExpectedOutput(String expectedOutput) {
+        this.expectedOutput = expectedOutput;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    public void setErrorMessage(String errorMessage) {
+        this.errorMessage = errorMessage;
+    }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/CodeExecutionService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/CodeExecutionService.java
@@ -14,7 +14,10 @@ import ch.uzh.ifi.hase.soprafs26.rest.dto.CodeSubmissionDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.JudgeBatchRequestDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.JudgeBatchResultDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.JudgeRequestDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.JudgeResultDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.JudgeTokenDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.TestCaseFeedbackDTO;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -24,6 +27,8 @@ import org.springframework.web.server.ResponseStatusException;
 import java.util.ArrayList;
 import java.util.List;
 import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.Objects;
 
 @Service
 @Transactional
@@ -86,6 +91,11 @@ public class CodeExecutionService {
         submissionRepository.save(submission);
         submissionRepository.flush();
 
+        List<TestCaseFeedbackDTO> testCaseFeedback =
+        submission.getStatus() == SubmissionStatus.FINISHED
+                ? mapToTestCaseFeedback(problem.getTestCases(), batchResult)
+                : Collections.emptyList();
+
         CodeRunDTO response = new CodeRunDTO();
         response.setGameSessionId(gameSessionId);
         response.setProblemId(problemId);
@@ -93,8 +103,13 @@ public class CodeExecutionService {
         response.setSubmissionStatus(submission.getStatus());
         response.setVerdict(submission.getVerdict());
         response.setPassedTestCases(submission.getPassedTestCases());
-        response.setTotalTestCases(submission.getTotalTestCases());
-        response.setJudgeResultsJson(submission.getJudgeResultsJson());
+        response.setTotalTestCases(
+            submission.getStatus() == SubmissionStatus.FINISHED // if the submission is finished, we set the total test cases to the size of the test case feedback list, which corresponds to the number of test cases that were actually executed and for which we have results. 
+                    ? testCaseFeedback.size()
+                    : submission.getTotalTestCases()
+            );
+        response.setTestCases(testCaseFeedback);
+
 
         return response;
     }
@@ -147,6 +162,11 @@ public class CodeExecutionService {
         submissionRepository.save(submission);
         submissionRepository.flush();
 
+        List<TestCaseFeedbackDTO> testCaseFeedback =
+        submission.getStatus() == SubmissionStatus.FINISHED
+                ? mapToTestCaseFeedback(problem.getTestCases(), batchResult)
+                : Collections.emptyList();
+
         CodeSubmissionDTO response = new CodeSubmissionDTO();
         response.setGameSessionId(gameSessionId);
         response.setProblemId(problemId);
@@ -154,8 +174,12 @@ public class CodeExecutionService {
         response.setSubmissionStatus(submission.getStatus());
         response.setVerdict(submission.getVerdict());
         response.setPassedTestCases(submission.getPassedTestCases());
-        response.setTotalTestCases(submission.getTotalTestCases());
-        response.setJudgeResultsJson(submission.getJudgeResultsJson());
+        response.setTotalTestCases(
+                submission.getStatus() == SubmissionStatus.FINISHED // if the submission is finished, we set the total test cases to the size of the test case feedback list, which corresponds to the number of test cases that were actually executed and for which we have results.
+                        ? testCaseFeedback.size()
+                        : submission.getTotalTestCases()
+        );
+        response.setTestCases(testCaseFeedback);
 
         return response;
     }
@@ -497,11 +521,18 @@ public class CodeExecutionService {
                         playerSessionId,
                         SubmissionType.RUN
                 );
+
         if (submission == null) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "No run submission found");
         }
 
         submission = refreshSubmissionIfNeeded(submission);
+
+        // We only map the test case feedback if the submission is finished, otherwise we return an empty list, because the results are not final yet and we don't want to confuse the user with intermediate results that might change.
+        List<TestCaseFeedbackDTO> testCaseFeedback =
+        submission.getStatus() == SubmissionStatus.FINISHED
+                ? mapStoredTestCaseFeedback(problemId, submission)
+                : Collections.emptyList();
 
         CodeRunDTO response = new CodeRunDTO();
         response.setGameSessionId(gameSessionId);
@@ -511,7 +542,7 @@ public class CodeExecutionService {
         response.setVerdict(submission.getVerdict());
         response.setPassedTestCases(submission.getPassedTestCases());
         response.setTotalTestCases(submission.getTotalTestCases());
-        response.setJudgeResultsJson(submission.getJudgeResultsJson());
+        response.setTestCases(testCaseFeedback);
 
         return response;
     }
@@ -534,11 +565,18 @@ public class CodeExecutionService {
                         playerSessionId,
                         SubmissionType.SUBMIT
                 );
+
         if (submission == null) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "No final submission found");
         }
 
         submission = refreshSubmissionIfNeeded(submission);
+
+        // We only map the test case feedback if the submission is finished, otherwise we return an empty list, because the results are not final yet and we don't want to confuse the user with intermediate results that might change.
+        List<TestCaseFeedbackDTO> testCaseFeedback =
+        submission.getStatus() == SubmissionStatus.FINISHED
+                ? mapStoredTestCaseFeedback(problemId, submission)
+                : Collections.emptyList();
 
         CodeSubmissionDTO response = new CodeSubmissionDTO();
         response.setGameSessionId(gameSessionId);
@@ -548,7 +586,7 @@ public class CodeExecutionService {
         response.setVerdict(submission.getVerdict());
         response.setPassedTestCases(submission.getPassedTestCases());
         response.setTotalTestCases(submission.getTotalTestCases());
-        response.setJudgeResultsJson(submission.getJudgeResultsJson());
+        response.setTestCases(testCaseFeedback);
 
         return response;
     }
@@ -620,5 +658,136 @@ public class CodeExecutionService {
             submission.setVerdict(Verdict.PENDING);
         }
     }
+
+    /**
+     * 
+     * This method maps the list of test cases and the corresponding Judge0 
+     * batch result to a list of TestCaseFeedbackDTOs that can be sent back to the frontend.
+     * 
+     * 
+     */
+    private List<TestCaseFeedbackDTO> mapToTestCaseFeedback(
+        List<TestCase> testCases,
+        JudgeBatchResultDTO batchResult) {
+
+        List<TestCaseFeedbackDTO> feedbackList = new ArrayList<>();
+
+        if (testCases == null || testCases.isEmpty()) {
+            return feedbackList;
+        }
+        // We get the list of JudgeResultDTOs from the batch result. 
+        List<JudgeResultDTO> judgeResults =
+                (batchResult != null && batchResult.getSubmissions() != null)
+                        ? batchResult.getSubmissions()
+                        : Collections.emptyList();
+
+        // We iterate over the test cases and the corresponding Judge results in parallel and create a TestCaseFeedbackDTO for each test case.
+        for (int i = 0; i < testCases.size(); i++) {
+            TestCase testCase = testCases.get(i);
+            JudgeResultDTO judgeResult = i < judgeResults.size() ? judgeResults.get(i) : null;
+
+            TestCaseFeedbackDTO feedbackDTO = new TestCaseFeedbackDTO();
+            feedbackDTO.setTestCaseId(
+                testCase.getTestCaseId() != null
+                        ? testCase.getTestCaseId().intValue()
+                        : i
+            );
+            
+            feedbackDTO.setExpectedOutput(testCase.getExpectedOutput());
+
+            if (judgeResult == null) {
+                feedbackDTO.setResult("ERROR");
+                feedbackDTO.setActualOutput(null);
+                feedbackDTO.setErrorMessage("Missing Judge0 result for test case.");
+                feedbackList.add(feedbackDTO);
+                continue;
+            }
+
+
+            // We consider a test case as having an execution error if there is any stderr output, or any compile output, or any message, or if the status id is not 3 (Correct Answer) or 4 (Wrong Answer).
+            String stdout = judgeResult.getStdout();
+            String stderr = judgeResult.getStderr();
+            String compileOutput = judgeResult.getCompile_output();
+            String message = judgeResult.getMessage();
+
+            feedbackDTO.setActualOutput(stdout != null ? stdout.trim() : null);
+
+            Integer statusId = judgeResult.getStatus() != null ? judgeResult.getStatus().getId() : null;
+
+            boolean hasExecutionError =
+                    (stderr != null && !stderr.isBlank()) ||
+                    (compileOutput != null && !compileOutput.isBlank()) ||
+                    (message != null && !message.isBlank()) ||
+                    (statusId != null && statusId != 3 && statusId != 4);
+
+            if (hasExecutionError) {
+                feedbackDTO.setResult("ERROR");
+
+                if (compileOutput != null && !compileOutput.isBlank()) {
+                    feedbackDTO.setErrorMessage(compileOutput.trim());
+                }
+                else if (stderr != null && !stderr.isBlank()) {
+                    feedbackDTO.setErrorMessage(stderr.trim());
+                }
+                else if (message != null && !message.isBlank()) {
+                    feedbackDTO.setErrorMessage(message.trim());
+                }
+                else if (judgeResult.getStatus() != null
+                        && judgeResult.getStatus().getDescription() != null) {
+                    feedbackDTO.setErrorMessage(judgeResult.getStatus().getDescription());
+                }
+                else {
+                    feedbackDTO.setErrorMessage("Unknown execution error.");
+                }
+            }
+            else { // If there is no execution error, we check if the output matches the expected output. We normalize both outputs by trimming whitespace and replacing newlines
+                String expected = normalizeOutput(testCase.getExpectedOutput());
+                String actual = normalizeOutput(stdout);
+
+                if (Objects.equals(expected, actual)) {
+                    feedbackDTO.setResult("PASS");
+                    feedbackDTO.setErrorMessage(null);
+                }
+                else {
+                    feedbackDTO.setResult("FAIL");
+                    feedbackDTO.setErrorMessage(null);
+                }
+            }
+
+            feedbackList.add(feedbackDTO);
+        }
+
+        return feedbackList;
+    }
+
+    private String normalizeOutput(String output) {
+        if (output == null) {
+            return null;
+        }
+        return output.trim().replace("\r\n", "\n");
+    }
+
+    private List<TestCaseFeedbackDTO> mapStoredTestCaseFeedback(Long problemId, Submission submission) {
+        if (problemId == null) {
+            return Collections.emptyList();
+        }
+
+        if (submission == null || submission.getJudgeResultsJson() == null || submission.getJudgeResultsJson().isBlank()) {
+            return Collections.emptyList();
+        }
+
+        try {
+            Problem problem = problemService.getProblemById(problemId);
+            JudgeBatchResultDTO batchResult = objectMapper.readValue(
+                    submission.getJudgeResultsJson(),
+                    JudgeBatchResultDTO.class
+            );
+
+            return mapToTestCaseFeedback(problem.getTestCases(), batchResult);
+        } catch (Exception e) {
+            return Collections.emptyList();
+        }
+    }
+
 
 }


### PR DESCRIPTION
Basically CodeRunDTO/CodeSubmissionDTO give a response and then testCases<TestCaseFeedbackDTO[>.
Without TestCaseFeedbackDTO it would be a real mess when getting judge responses. Updated the rest spec accordingly
    

TestCaseFeedbackDTO (NEW 18.4) 
Purpose: 
The purpose of TestCaseFeedbackDTO is to provide structured feedback for one predefined test case used during code execution or submission evaluation. It allows the frontend to present clear per-test-case feedback such as pass, fail, or error, together with actual and expected output. 
Specification: 

testCaseId<int> 
result<string> 
actualOutput<string> 
expectedOutput<string> 
errorMessage<string> 

refer to:
<img width="477" height="468" alt="image" src="https://github.com/user-attachments/assets/fb9c987c-73fa-4ed3-b5d1-cb56be15567d" />
