### PR TITLE
Issue 161 should be finished including tests putting under review

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/Application.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/Application.java
@@ -5,12 +5,16 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @RestController
 @SpringBootApplication
+@EnableScheduling
 public class Application {
 
 	public static void main(String[] args) {
@@ -32,4 +36,14 @@ public class Application {
 			}
 		};
 	}
+
+	@Bean
+    public TaskScheduler taskScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(4);
+        scheduler.setThreadNamePrefix("game-timer-");
+        scheduler.setWaitForTasksToCompleteOnShutdown(false); // just let the timer die when app crashes
+        scheduler.initialize();
+        return scheduler;
+    }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/GameRoundDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/GameRoundDTO.java
@@ -1,5 +1,7 @@
 package ch.uzh.ifi.hase.soprafs26.rest.dto;
 
+import java.time.Instant;
+
 import ch.uzh.ifi.hase.soprafs26.constant.GameStatus;
 
 public class GameRoundDTO {
@@ -17,6 +19,10 @@ public class GameRoundDTO {
     private String inputFormat;
     private String outputFormat;
     private String constraints;
+
+    private Instant serverTime; 
+    private Instant endsAt;
+    private long totalDurationSeconds; 
 
     public Long getGameSessionId() {
         return gameSessionId;
@@ -89,5 +95,26 @@ public class GameRoundDTO {
     }
     public void setConstraints(String constraints) {
         this.constraints = constraints;
+    }
+
+    public Instant getServerTime() {
+        return serverTime;
+    }
+    public void setServerTime(Instant serverTime) {
+        this.serverTime = serverTime;
+    }
+
+    public Instant getEndsAt() {
+        return endsAt;
+    }
+    public void setEndsAt(Instant endsAt) {
+        this.endsAt = endsAt;
+    }
+
+    public long getTotalDurationSeconds() {
+        return totalDurationSeconds;
+    }
+    public void setTotalDurationSeconds(long totalDurationSeconds) {
+        this.totalDurationSeconds = totalDurationSeconds;
     }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/GameTimeWarningDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/GameTimeWarningDTO.java
@@ -1,0 +1,24 @@
+package ch.uzh.ifi.hase.soprafs26.rest.dto;
+
+public class GameTimeWarningDTO {
+
+    private Long gameSessionId;
+    private Long remainingTimeSeconds;
+
+    public Long getGameSessionId() {
+        return gameSessionId;
+    }
+
+    public void setGameSessionId(Long gameSessionId) {
+        this.gameSessionId = gameSessionId;
+    }
+
+    public Long getRemainingTimeSeconds() {
+        return remainingTimeSeconds;
+    }
+
+    public void setRemainingTimeSeconds(Long remainingTimeSeconds) {
+        this.remainingTimeSeconds = remainingTimeSeconds;
+    }
+    
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/GameService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/GameService.java
@@ -1,14 +1,21 @@
 package ch.uzh.ifi.hase.soprafs26.service;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledFuture;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.scheduling.TaskScheduler;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -25,13 +32,20 @@ import ch.uzh.ifi.hase.soprafs26.repository.RoomRepository;
 import ch.uzh.ifi.hase.soprafs26.repository.UserRepository;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.GameEndDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.GameRoundDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.GameTimeWarningDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.PlayerScoreDTO;
 import jakarta.transaction.Transactional;
 
 @Service
 @Transactional
 public class GameService {
+
+ 
     
+    private final Duration GAME_DURATION = Duration.ofMinutes(15);
+    private final Duration WARNING_OFFSET = Duration.ofMinutes(1);
+    private final TaskScheduler taskScheduler;
+    private final Map<Long, List<ScheduledFuture<?>>> scheduledTasksByGame = new ConcurrentHashMap<>();
     private final RoomRepository roomRepository;
     private final UserService userService;
     private final UserRepository userRepository;
@@ -41,7 +55,7 @@ public class GameService {
     private final WsRoomService wsRoomService;
     private final WsGameService wsGameService;
 
-    public GameService(RoomRepository roomRepository, UserService userService,ProblemService problemService, GameSessionRepository gameSessionRepository, UserRepository userRepository, SimpMessagingTemplate messagingTemplate, WsRoomService wsRoomService, WsGameService wsGameService) {
+    public GameService(RoomRepository roomRepository, UserService userService,ProblemService problemService, GameSessionRepository gameSessionRepository, UserRepository userRepository, SimpMessagingTemplate messagingTemplate, WsRoomService wsRoomService, WsGameService wsGameService, TaskScheduler taskScheduler) {
         this.roomRepository = roomRepository;
         this.userService = userService;
         this.problemService = problemService;
@@ -50,6 +64,7 @@ public class GameService {
         this.messagingTemplate = messagingTemplate;
         this.wsRoomService = wsRoomService;
         this.wsGameService = wsGameService;
+        this.taskScheduler = taskScheduler;
     }
 
     public void createGameSession(Long hostId, Long roomId){
@@ -110,6 +125,12 @@ public class GameService {
         gameSession = gameSessionRepository.save(gameSession);
         gameSessionRepository.flush();
 
+        Instant startedAtInstant = gameSession.getStartedAt().atZone(ZoneId.systemDefault())
+                                              .toInstant();
+        
+        Instant endAtInstant = startedAtInstant.plus(GAME_DURATION);
+        Instant serverTimeNow = Instant.now();
+
         // prepare and send personalised GameRoundDTO via WS
         for(PlayerSession playerSession : gameSession.getPlayerSessions()) {
             
@@ -120,6 +141,10 @@ public class GameService {
             gameRoundDTO.setPlayerId(playerSession.getPlayer().getId());
             gameRoundDTO.setCurrentScore(0);
             gameRoundDTO.setNumOfSkippedProblems(0);
+
+            gameRoundDTO.setServerTime(serverTimeNow);
+            gameRoundDTO.setEndsAt(endAtInstant);
+            gameRoundDTO.setTotalDurationSeconds(GAME_DURATION.getSeconds());
 
             Problem firstProblem = gameSession.getProblems().get(0); // get first problem
             gameRoundDTO.setProblemId(firstProblem.getProblemId());
@@ -132,9 +157,17 @@ public class GameService {
             //send personalised message to each player
             wsRoomService.notifyPlayerGameStarted(gameRoundDTO);
         }
+        scheduleGameTimer(gameSession.getGameSessionId(), startedAtInstant);
     }
 
     public void endGameSession(GameSession gameSession, GameEndReason gameEndReason) {
+        // cancled the scheduled timer tasks (if the game is ending earlier)
+        List<ScheduledFuture<?>> pending = scheduledTasksByGame.remove(gameSession.getGameSessionId());
+        if (pending != null) {
+            pending.forEach(f -> f.cancel(false));
+        }
+
+
         gameSession.setGameStatus(GameStatus.ENDED);
         gameSession.setEndedAt(LocalDateTime.now());
         gameSession.setGameEndReason(gameEndReason);
@@ -175,4 +208,30 @@ public class GameService {
         //fire room-wide game-end msg
         wsGameService.notifyPlayerGameEnded(gameEndDTO);
     }
+
+
+    private void scheduleGameTimer(Long gameSessionId, Instant startedAt) {
+        Instant warningAt = startedAt.plus(GAME_DURATION.minus(WARNING_OFFSET));
+        Instant endAt = startedAt.plus(GAME_DURATION);
+
+        ScheduledFuture<?> warningFuture = taskScheduler.schedule(() -> {
+            GameSession session = gameSessionRepository.findByGameSessionId(gameSessionId);
+            if (session == null || session.getGameStatus() != GameStatus.ACTIVE)
+                return;
+            GameTimeWarningDTO dto = new GameTimeWarningDTO();
+            dto.setGameSessionId(gameSessionId);
+            dto.setRemainingTimeSeconds(WARNING_OFFSET.getSeconds());
+            wsGameService.notifyPlayerGameTimeWarning(dto);
+        }, warningAt);
+
+        ScheduledFuture<?> endFuture = taskScheduler.schedule(() -> {
+            GameSession session = gameSessionRepository.findByGameSessionId(gameSessionId);
+            if (session == null || session.getGameStatus() != GameStatus.ACTIVE)
+                return;
+            endGameSession(session, GameEndReason.TIME_UP);
+        }, endAt);
+
+        scheduledTasksByGame.put(gameSessionId, List.of(warningFuture, endFuture));
+    }
 }
+// https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/concurrent/ScheduledFuture.html

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/WsGameService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/WsGameService.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 
 import ch.uzh.ifi.hase.soprafs26.rest.dto.GameEndDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.GamePointsUpdateDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.GameTimeWarningDTO;
 
 @Service
 public class WsGameService {
@@ -18,9 +19,10 @@ public class WsGameService {
         this.simpMessagingTemplate = simpMessagingTemplate;
     }
 
-    //ATM PLAYERS HAVE TO MAKE TWO SUBSCRIPTIONS:
+    //ATM PLAYERS HAVE TO MAKE THREE SUBSCRIPTIONS:
     // - 1.: /topic/game/{gameSessionId}/end
     // - 2.: /topic/game/{gameSessionId}/points-update
+    // - 3.: /topic/game/{gameSessionId}/time-warning
 
     public void notifyPlayerGameEnded(GameEndDTO gameEndDTO) {
         Long gameSessionId = gameEndDTO.getGameSessionId();
@@ -43,5 +45,14 @@ public class WsGameService {
         log.info("Sent points update to gameSession with gameSessionId=" + gameSessionId + " regarding playerSessionId=" + playerSessionId);
         log.info("New current points: " + gamePointsUpdateDTO.getCurrentScore() + " of playerSessionId=" + playerSessionId);
     }
-    
+
+    public void notifyPlayerGameTimeWarning(GameTimeWarningDTO gameTimeWarningDTO) {
+        Long gameSessionid = gameTimeWarningDTO.getGameSessionId();
+        simpMessagingTemplate.convertAndSend(
+            "/topic/game/" + gameSessionid + "/time-warning",gameTimeWarningDTO
+        );
+        log.info("Sent time warning ({}s remaining) to gameSessionId={}",
+            gameTimeWarningDTO.getRemainingTimeSeconds(), gameSessionid
+        );
+    }
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/GameServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/GameServiceTest.java
@@ -13,14 +13,13 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.scheduling.TaskScheduler;
 import org.springframework.web.server.ResponseStatusException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
@@ -41,7 +40,12 @@ import ch.uzh.ifi.hase.soprafs26.repository.RoomRepository;
 import ch.uzh.ifi.hase.soprafs26.repository.UserRepository;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.GameEndDTO;
 
-public class GameServiceTest {
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.ScheduledFuture;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.GameTimeWarningDTO;
+
+class GameServiceTest {
 
     @Mock
     private RoomRepository roomRepository;
@@ -63,6 +67,18 @@ public class GameServiceTest {
   
     @Mock
     private WsRoomService wsRoomService;
+
+    @Mock
+    private WsGameService wsGameService;
+
+    @Mock
+    private TaskScheduler taskScheduler;
+
+    @Mock
+    private ScheduledFuture<Object> warningFuture;
+
+    @Mock
+    private ScheduledFuture<Object> endFuture;
 
     @InjectMocks
     private GameService gameService;
@@ -116,7 +132,14 @@ public class GameServiceTest {
         given(userService.getUserById(gameHost.getId())).willReturn(gameHost);
         given(userService.getUserById(player2.getId())).willReturn(player2);
         given(gameSessionRepository.save(any(GameSession.class)))
-            .willAnswer(invocation -> invocation.getArgument(0));
+            .willAnswer(invocation -> {
+                GameSession s = invocation.getArgument(0);
+                s.setGameSessionId(99L);
+                return s;
+            });
+        given(taskScheduler.schedule(any(Runnable.class), any(Instant.class)))
+            .willReturn((ScheduledFuture) warningFuture, (ScheduledFuture) endFuture);
+
         doNothing().when(wsRoomService).notifyPlayerGameStarted(Mockito.any());
 
         gameService.createGameSession(gameHost.getId(), testRoom.getRoomId());
@@ -190,6 +213,160 @@ public class GameServiceTest {
 
         assertThrows(ResponseStatusException.class, () ->
                 gameService.createGameSession(gameHost.getId(), testRoom.getRoomId()));
+    }
+
+    @Test
+    void createGameSessionSchedulesWarningAndEndTasks() {
+        Problem p1 = new Problem();
+        p1.setProblemId(1L);
+        testRoom.setNumOfProblems(1);
+
+        given(roomRepository.findByRoomId(testRoom.getRoomId())).willReturn(testRoom);
+        given(userRepository.findUserById(gameHost.getId())).willReturn(gameHost);
+        given(problemService.getAllProblems()).willReturn(List.of(p1));
+        given(userService.getUserById(gameHost.getId())).willReturn(gameHost);
+        given(userService.getUserById(player2.getId())).willReturn(player2);
+        given(gameSessionRepository.save(any(GameSession.class)))
+            .willAnswer(invocation -> {
+                GameSession s = invocation.getArgument(0);
+                s.setGameSessionId(11L);
+                return s;
+            });
+        given(taskScheduler.schedule(any(Runnable.class), any(Instant.class)))
+            .willReturn((ScheduledFuture) warningFuture, (ScheduledFuture) endFuture);
+
+        gameService.createGameSession(gameHost.getId(), testRoom.getRoomId());
+
+        ArgumentCaptor<Instant> whenCaptor = ArgumentCaptor.forClass(Instant.class);
+        verify(taskScheduler, Mockito.times(2))
+            .schedule(any(Runnable.class), whenCaptor.capture());
+
+        List<Instant> scheduledAt = whenCaptor.getAllValues();
+        long firstOffsetSec  = Duration.between(Instant.now(), scheduledAt.get(0)).getSeconds();
+        long secondOffsetSec = Duration.between(Instant.now(), scheduledAt.get(1)).getSeconds();
+        // allow a few seconds of test slack
+        assertEquals(14 * 60, firstOffsetSec, 5);
+        assertEquals(15 * 60, secondOffsetSec, 5);
+    }
+
+    @Test
+    void warningTask_whenFired_broadcastsTimeWarning() {
+        Problem p1 = new Problem();
+        p1.setProblemId(1L);
+        testRoom.setNumOfProblems(1);
+
+        given(roomRepository.findByRoomId(testRoom.getRoomId())).willReturn(testRoom);
+        given(userRepository.findUserById(gameHost.getId())).willReturn(gameHost);
+        given(problemService.getAllProblems()).willReturn(List.of(p1));
+        given(userService.getUserById(Mockito.anyLong())).willReturn(gameHost);
+        given(gameSessionRepository.save(any(GameSession.class)))
+            .willAnswer(inv -> {
+                GameSession s = inv.getArgument(0);
+                s.setGameSessionId(42L);
+                return s;
+            });
+        given(taskScheduler.schedule(any(Runnable.class), any(Instant.class)))
+            .willReturn((ScheduledFuture) warningFuture, (ScheduledFuture) endFuture);
+
+        gameService.createGameSession(gameHost.getId(), testRoom.getRoomId());
+
+        ArgumentCaptor<Runnable> runnableCaptor = ArgumentCaptor.forClass(Runnable.class);
+        verify(taskScheduler, Mockito.times(2))
+        .schedule(runnableCaptor.capture(), any(Instant.class));
+
+        // stub the repo re-fetch that the runnable performs
+        GameSession active = new GameSession();
+        active.setGameSessionId(42L);
+        active.setGameStatus(GameStatus.ACTIVE);
+        given(gameSessionRepository.findByGameSessionId(42L)).willReturn(active);
+
+        // fire the warning runnable (first one scheduled)
+        runnableCaptor.getAllValues().get(0).run();
+
+        ArgumentCaptor<GameTimeWarningDTO> warnCaptor = ArgumentCaptor.forClass(GameTimeWarningDTO.class);
+        verify(wsGameService).notifyPlayerGameTimeWarning(warnCaptor.capture());
+        assertEquals(60L, warnCaptor.getValue().getRemainingTimeSeconds());
+        assertEquals(42L, warnCaptor.getValue().getGameSessionId());
+    }
+
+    @Test
+    void endTask_whenFired_endsGameWithTimeUp() {
+        Problem p1 = new Problem();
+        p1.setProblemId(1L);
+        testRoom.setNumOfProblems(1);
+
+        given(roomRepository.findByRoomId(testRoom.getRoomId())).willReturn(testRoom);
+        given(userRepository.findUserById(gameHost.getId())).willReturn(gameHost);
+        given(problemService.getAllProblems()).willReturn(List.of(p1));
+        given(userService.getUserById(Mockito.anyLong())).willReturn(gameHost);
+        given(gameSessionRepository.save(any(GameSession.class)))
+            .willAnswer(inv -> {
+                GameSession s = inv.getArgument(0);
+                s.setGameSessionId(77L);
+                return s;
+            });
+        given(taskScheduler.schedule(any(Runnable.class), any(Instant.class)))
+            .willReturn((ScheduledFuture) warningFuture, (ScheduledFuture) endFuture);
+
+                gameService.createGameSession(gameHost.getId(), testRoom.getRoomId());
+
+        ArgumentCaptor<Runnable> runnableCaptor = ArgumentCaptor.forClass(Runnable.class);
+        verify(taskScheduler, Mockito.times(2))
+            .schedule(runnableCaptor.capture(), any(Instant.class));
+
+        // build a minimal ACTIVE session 
+        GameSession active = new GameSession();
+        active.setGameSessionId(77L);
+        active.setGameStatus(GameStatus.ACTIVE);
+        PlayerSession ps = new PlayerSession();
+        ps.setPlayerSessionId(1L);
+        ps.setPlayer(gameHost);
+        ps.setCurrentScore(0);
+        ps.setCurrentProblemIndex(0);
+        ps.setPlayerSessionStatus(PlayerSessionStatus.PLAYING);
+        active.setPlayerSessions(new ArrayList<>(List.of(ps)));
+        given(gameSessionRepository.findByGameSessionId(77L)).willReturn(active);
+
+        // fire the end run
+        runnableCaptor.getAllValues().get(1).run();
+
+        ArgumentCaptor<GameEndDTO> endCaptor = ArgumentCaptor.forClass(GameEndDTO.class);
+        verify(wsGameService).notifyPlayerGameEnded(endCaptor.capture());
+        assertEquals(GameEndReason.TIME_UP, endCaptor.getValue().getGameEndReason());
+        assertEquals(GameStatus.ENDED, active.getGameStatus());
+    }
+
+    @Test
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    void endGameSession_earlyFinish_cancelsScheduledTasks() {
+        Problem p1 = new Problem();
+        p1.setProblemId(1L);
+        testRoom.setNumOfProblems(1);
+
+        given(roomRepository.findByRoomId(testRoom.getRoomId())).willReturn(testRoom);
+        given(userRepository.findUserById(gameHost.getId())).willReturn(gameHost);
+        given(problemService.getAllProblems()).willReturn(List.of(p1));
+        given(userService.getUserById(Mockito.anyLong())).willReturn(gameHost);
+        given(gameSessionRepository.save(any(GameSession.class)))
+            .willAnswer(inv -> {
+                GameSession s = inv.getArgument(0);
+                s.setGameSessionId(55L);
+                return s;
+            });
+        given(taskScheduler.schedule(any(Runnable.class), any(Instant.class)))
+            .willReturn((ScheduledFuture) warningFuture, (ScheduledFuture) endFuture);
+
+        gameService.createGameSession(gameHost.getId(), testRoom.getRoomId());
+
+
+        ArgumentCaptor<GameSession> savedCaptor = ArgumentCaptor.forClass(GameSession.class);
+        verify(gameSessionRepository).save(savedCaptor.capture());
+        GameSession saved = savedCaptor.getValue();
+
+        gameService.endGameSession(saved, GameEndReason.PLAYER_FINISHED);
+
+        verify(warningFuture).cancel(false);
+        verify(endFuture).cancel(false);
     }
 
     // --- endGameSession tests ---


### PR DESCRIPTION
+ Adds an automatic game timeout: each game session now ends after a fixed 15 (OF COURSE CHANGEABLE) minutes. Players receive a "1 minute remaining" warning broadcast at +14 min so the frontend can render a "stressed-timer UI" and a final GameEndDTO with gameEndReason = TIME_UP at +15 min.

If a player finishes all problems before the timer expires, the scheduled tasks are cancelled. 


CHANGES
Application.java:
Added @EnableScheduling + a ThreadPoolTaskScheduler bean so concurrent games don't block each other.

GameService.java:
Added GAME_DURATION / WARNING_OFFSET constants. Schedules two tasks per game in createGameSession. Cancels them at the top of endGameSession so early finishes don't trigger a late TIME_UP.

WsGameService.java
New notifyPlayerGameTimeWarning() broadcasting on /topic/game/{id}/time-warning

NEW GameTimeWarningDTO.java:
DTO: gameSessionId, remainingTimeSeconds.

GameRoundDTO.java
Added serverTime, endsAt, totalDurationSeconds so the frontend can render a live countdown (ticks locally, server doesn't broadcast every second).

NEW WEBSOCKET TOPIC
/topic/game/{gameSessionId}/time-warning 
