### PR TITLE
Feature/194 leave room

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/RoomController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/RoomController.java
@@ -13,7 +13,7 @@ import ch.uzh.ifi.hase.soprafs26.service.RoomService;
 
 import java.util.List;
 import java.util.Map;
-import org.springframework.web.bind.annotation.GetMapping;
+
 
 
 @RestController
@@ -78,4 +78,12 @@ public class RoomController {
                      .toList();
     }
 
+    @PostMapping("/rooms/{roomId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void leaveRoom(@PathVariable("roomId") Long roomId,
+                                  @RequestHeader(value = "userId", required = false) Long userId, 
+                                  @RequestHeader(value = "token", required = false) String token) {
+
+        roomService.leaveRoom(roomId, userId, token);
+    }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/RoomService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/RoomService.java
@@ -22,14 +22,17 @@ public class RoomService {
     private final RoomRepository roomRepository;
     private final UserService userService;
     private final ProblemService problemService;
+    private final WsRoomService wsRoomService;
 
     public RoomService(@Qualifier("roomRepository") RoomRepository roomRepository,
                                                     UserRepository userRepository,
                                                     UserService userService,
-                                                    ProblemService problemService) {
+                                                    ProblemService problemService,
+                                                    WsRoomService wsRoomService) {
         this.roomRepository = roomRepository;
         this.userService = userService;
         this.problemService = problemService;
+        this.wsRoomService = wsRoomService;
     }
 
     public Room createRoom(Room roomInput, Long userId, String token) {
@@ -95,6 +98,44 @@ public class RoomService {
 
         return targetRoom;
     }
+
+    public void leaveRoom(Long roomId, Long userId, String token) {
+        userService.verifyTokenAndUserId(token, userId);
+
+        Room room = roomRepository.findByRoomId(roomId);
+
+        if (room == null) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Room was not found!");
+        }
+        if (!room.getPlayerIds().contains(userId)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Player must be in Lobby to have access to room details!");
+        }
+        
+        User leavingUser = userService.getUserById(userId);
+
+        if (room.getHostUserId().equals(userId)){
+            //host leaves => room deleted
+            roomRepository.delete(room);
+            roomRepository.flush();
+
+            //fire WS-msg so that host realises what happened
+            wsRoomService.notifyRoomPlayerLeft(leavingUser, roomId, true);
+        }
+        else if (room.getCurrentNumPlayers() > 1) {
+            //non-host leaves => spot is freed
+            room.setCurrentNumPlayers(room.getCurrentNumPlayers() - 1);
+            room.setRoomOpen(true);
+            room.getPlayerIds().remove(userId);
+
+            roomRepository.saveAndFlush(room);
+            
+            //fire WS-msg so that host realises what happened
+            wsRoomService.notifyRoomPlayerLeft(leavingUser, roomId, false);
+        }
+        else {
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Room is in illegal state: A room cannot exist without host!");
+        }
+    } 
 
     public Room getRoomDetails(Long roomId, Long userId, String token) {
         userService.verifyTokenAndUserId(token, userId);

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/RoomService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/RoomService.java
@@ -22,23 +22,17 @@ public class RoomService {
     
     private final RoomRepository roomRepository;
     private final UserService userService;
-    private final ProblemService problemService;
     private final WsRoomService wsRoomService;
     private final ProblemRepository problemRepository;
 
     public RoomService(@Qualifier("roomRepository") RoomRepository roomRepository,
                                                     UserRepository userRepository,
                                                     UserService userService,
-                                                    ProblemService problemService,
-                                                    WsRoomService wsRoomService) {
-        this.roomRepository = roomRepository;
-        this.userService = userService;
-        this.problemService = problemService;
-        this.wsRoomService = wsRoomService;
+                                                    WsRoomService wsRoomService,
                                                     ProblemRepository problemRepository) {
         this.roomRepository = roomRepository;
         this.userService = userService;
-        this.problemService = problemService;
+        this.wsRoomService = wsRoomService;
         this.problemRepository = problemRepository;
     }
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/WsRoomService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/WsRoomService.java
@@ -8,7 +8,6 @@ import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 
 import ch.uzh.ifi.hase.soprafs26.entity.User;
-import ch.uzh.ifi.hase.soprafs26.rest.dto.GamePointsUpdateDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.GameRoundDTO;
 
 @Service
@@ -46,5 +45,22 @@ public class WsRoomService {
             gameRoundDTO
         );
         log.info("GameRoundDTO sent to: {}", player.getUsername());
+    }
+
+    public void notifyRoomPlayerLeft(User user, Long roomId, Boolean isHost){
+        String username = user.getUsername();
+
+        log.info("User=" + username + " is leaving room=" + roomId);
+        log.info("User=" + username + " isHost=" + isHost);
+
+        Map<String, String> notification = Map.of(
+            "type", isHost ? "ROOM_CLOSED" : "PLAYER_LEFT",
+            "roomId", roomId.toString(),
+            "username", username,
+            "message", username + (isHost ? " closed the room. Room was deleted." : " left the room. Room persists.")
+        );
+        
+        log.info("Sending room-wide info to roomId=" + roomId);
+        simpMessagingTemplate.convertAndSend("/topic/room/" + roomId, notification);
     }
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/RoomControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/RoomControllerTest.java
@@ -4,8 +4,10 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.http.HttpStatus;
@@ -34,6 +36,7 @@ import ch.uzh.ifi.hase.soprafs26.constant.GameLanguage;
 import ch.uzh.ifi.hase.soprafs26.constant.GameMode;
 
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
 
 @WebMvcTest(RoomController.class)
 class RoomControllerTest {
@@ -42,6 +45,22 @@ class RoomControllerTest {
 
     @MockitoBean
     private RoomService roomService;
+
+    private User testUser;
+    private Room testRoom;
+
+    @BeforeEach
+    void setup() {
+        MockitoAnnotations.openMocks(this);
+
+        testUser = new User();
+        testUser.setId(1L);
+        testUser.setToken("validToken");
+
+        testRoom = new Room();
+        testRoom.setRoomId(3L);
+        testRoom.setHostUserId(testUser.getId());
+        }
     
     // Create Room Success 201
     @Test
@@ -473,6 +492,60 @@ class RoomControllerTest {
                         .andExpect(jsonPath("$[1].timeLimitSeconds", is(180)))
                         .andExpect(jsonPath("$[1].numOfProblems", is(8)));
         }
+
+        //Leave room success 204
+        @Test
+        void leaveRoom_success() throws Exception {
+
+                doNothing().when(roomService).leaveRoom(testRoom.getRoomId(), testUser.getId(), testUser.getToken());
+
+                MockHttpServletRequestBuilder postRequest = post("/rooms/{roomId}", testRoom.getRoomId())
+                        .header("token", testUser.getToken())
+                        .header("userId", testUser.getId())
+                        .contentType("application/json");
+
+                mockMvc.perform(postRequest)
+                        .andExpect(status().isNoContent());
+        }
+
+        //Leave room fail 404
+        @Test
+        void leaveRoom_roomIdInvalid_notFound() throws Exception {
+
+                Long invalidRoomId = 4L;
+
+                String errorReason = "Room was not found!";
+                Mockito.doThrow(new ResponseStatusException(HttpStatus.NOT_FOUND, errorReason))
+				.when(roomService).leaveRoom(invalidRoomId, testUser.getId(), testUser.getToken());
+                
+                MockHttpServletRequestBuilder postRequest = post("/rooms/{roomId}", invalidRoomId)
+                        .header("token", testUser.getToken())
+                        .header("userId", testUser.getId())
+                        .contentType("application/json");
+
+                mockMvc.perform(postRequest)
+                        .andExpect(status().isNotFound())
+                        .andExpect(jsonPath("$.detail", is(errorReason)));
+        }
+
+        //Leave room fail 403
+        @Test
+        void leaveRoom_playerNotInRoom_forbidden() throws Exception {
+
+                String errorReason = "Player must be in Lobby to have access to room details!";
+                Mockito.doThrow(new ResponseStatusException(HttpStatus.FORBIDDEN, errorReason))
+				.when(roomService).leaveRoom(testRoom.getRoomId(), testUser.getId(), testUser.getToken());
+                
+                MockHttpServletRequestBuilder postRequest = post("/rooms/{roomId}", testRoom.getRoomId())
+                        .header("token", testUser.getToken())
+                        .header("userId", testUser.getId())
+                        .contentType("application/json");
+
+                mockMvc.perform(postRequest)
+                        .andExpect(status().isForbidden())
+                        .andExpect(jsonPath("$.detail", is(errorReason)));
+        }
+
     /**
 	 * @param object
 	 * @return string

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/RoomServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/RoomServiceTest.java
@@ -44,11 +44,16 @@ class RoomServiceTest {
     @Mock
     private ProblemService problemService;
 
+    @Mock
+    private WsRoomService wsRoomService;
+
     @InjectMocks
     private RoomService roomService;
 
     private Room testRoom;
     private User testUser;
+    private User player2;
+    private User testHost;
 
     @BeforeEach
     void setup() {
@@ -57,14 +62,23 @@ class RoomServiceTest {
         testUser = new User();
         testUser.setId(2L);
 
+        player2 = new User();
+        player2.setId(8L);
+        player2.setToken("validToken8");
+
+        testHost = new User();
+        testHost.setId(1L); 
+        testHost.setToken("validTokenHost");
+
         testRoom = new Room();
         testRoom.setRoomId(9L);
         testRoom.setRoomJoinCode("ABC123");
         testRoom.setRoomOpen(true);
         testRoom.setCurrentNumPlayers(1);
         Set<Long> playerIds = new HashSet<>();
-        playerIds.add(1L); //host with hostId=1L
+        playerIds.add(testHost.getId()); //host with hostId=1L
         testRoom.setPlayerIds(playerIds);
+        testRoom.setHostUserId(testHost.getId());
     }
 
     // Create Room Success 201
@@ -369,4 +383,81 @@ class RoomServiceTest {
         verify(userService).verifyTokenAndUserId(token, userId);
         verify(roomRepository, times(0)).findAll();
     }
+
+    //non-host leaves room sucess
+    @Test
+    void leaveRoom_nonHostLeaves_success() {
+        testRoom.getPlayerIds().add(player2.getId());
+        testRoom.setCurrentNumPlayers(testRoom.getCurrentNumPlayers()+1);
+        testRoom.setRoomOpen(false);
+
+        doNothing().when(userService).verifyTokenAndUserId(player2.getToken(), player2.getId());
+        given(roomRepository.findByRoomId(testRoom.getRoomId())).willReturn(testRoom);
+        given(userService.getUserById(player2.getId())).willReturn(player2);
+        doNothing().when(wsRoomService).notifyRoomPlayerLeft(player2, testRoom.getRoomId(), false);
+
+        roomService.leaveRoom(testRoom.getRoomId(), player2.getId(), player2.getToken());
+
+        assertEquals(1, testRoom.getCurrentNumPlayers());
+        assertTrue(testRoom.isRoomOpen());
+        assertEquals(1, testRoom.getPlayerIds().size());
+        assertFalse(testRoom.getPlayerIds().contains(player2.getId()));
+
+        verify(roomRepository, times(1)).saveAndFlush(testRoom);
+        verify(wsRoomService, times(1)).notifyRoomPlayerLeft(player2, testRoom.getRoomId(), false);
+
+    }
+
+    //host leaves room sucess
+    @Test
+    void leaveRoom_hostLeaves_success() {
+        testRoom.getPlayerIds().add(player2.getId());
+        testRoom.setCurrentNumPlayers(testRoom.getCurrentNumPlayers()+1);
+        testRoom.setRoomOpen(false);
+
+        doNothing().when(userService).verifyTokenAndUserId(testHost.getToken(), testHost.getId());
+        given(roomRepository.findByRoomId(testRoom.getRoomId())).willReturn(testRoom);
+        given(userService.getUserById(testHost.getId())).willReturn(testHost);
+        doNothing().when(wsRoomService).notifyRoomPlayerLeft(testHost, testRoom.getRoomId(), true);
+
+        roomService.leaveRoom(testRoom.getRoomId(), testHost.getId(), testHost.getToken());
+
+        verify(roomRepository, times(1)).delete(testRoom);
+        verify(roomRepository, times(1)).flush();
+        verify(wsRoomService, times(1)).notifyRoomPlayerLeft(testHost, testRoom.getRoomId(), true);
+
+    }
+
+    //leave room, room not found
+    @Test
+    void leaveRoom_invalidRoomId_throwsNotFound() {
+        
+        Long invalidRoomId = 4L; 
+
+        doNothing().when(userService).verifyTokenAndUserId(testHost.getToken(), testHost.getId());
+        given(roomRepository.findByRoomId(invalidRoomId)).willReturn(null);
+
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> {
+            roomService.leaveRoom(invalidRoomId, testHost.getId(), testHost.getToken());
+        });
+
+        assertEquals(HttpStatus.NOT_FOUND, exception.getStatusCode());
+    }
+
+    //leave room, user not even in room to leave
+    @Test
+    void leaveRoom_playerNotInRoom_throwsForbidden() {
+        
+        doNothing().when(userService).verifyTokenAndUserId(testUser.getToken(), testUser.getId());
+        given(roomRepository.findByRoomId(testRoom.getRoomId())).willReturn(testRoom);
+
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> {
+            roomService.leaveRoom(testRoom.getRoomId(), testUser.getId(), testUser.getToken());
+        });
+
+        assertEquals(HttpStatus.FORBIDDEN, exception.getStatusCode());
+    }
+
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/RoomServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/RoomServiceTest.java
@@ -47,6 +47,8 @@ class RoomServiceTest {
 
     @Mock
     private WsRoomService wsRoomService;
+
+    @Mock
     private ProblemRepository problemRepository;
 
     @InjectMocks

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/WsRoomServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/WsRoomServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.verify;
 
 import java.util.Map;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -19,6 +20,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.web.server.ResponseStatusException;
 
+import ch.uzh.ifi.hase.soprafs26.entity.Room;
 import ch.uzh.ifi.hase.soprafs26.entity.User;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.GameRoundDTO;
 
@@ -34,10 +36,31 @@ public class WsRoomServiceTest {
     @InjectMocks
     private WsRoomService wsRoomService;
 
+    private User testUser;
+    private User testUser7;
+    private Room testRoom;
+
+    @BeforeEach
+    void setup() {
+
+        testUser = new User();
+        testUser.setId(1L);
+        testUser.setUsername("testUser");
+        testUser.setToken("validToken");
+
+        testUser7 = new User();
+        testUser7.setId(7L);
+        testUser7.setUsername("testUser7");
+        testUser7.setToken("validToken7");
+
+        testRoom = new Room();
+        testRoom.setRoomId(1L);
+    }
+
     @Test
     void notifyPlayerJoinedRoom_host_success() {
         
-        Long roomId = 1L;
+        Long roomId = testRoom.getRoomId();
         String username = "testUser";
         boolean isHost = true;
 
@@ -59,7 +82,7 @@ public class WsRoomServiceTest {
     @Test
     void notifyPlayerJoinedRoom_player2_success() {
         
-        Long roomId = 1L;
+        Long roomId = testRoom.getRoomId();
         String username = "player2";
         boolean isHost = false;
 
@@ -79,11 +102,7 @@ public class WsRoomServiceTest {
 
     @Test
     void notifyPlayerGameStarted_success() {
-        
-        User testUser = new User();
-        testUser.setId(1L);
-        testUser.setUsername("testUser");
-
+    
         GameRoundDTO gameRoundDTO = new GameRoundDTO();
 
         Mockito.when(userService.getUserById(Mockito.any())).thenReturn(testUser);
@@ -99,10 +118,6 @@ public class WsRoomServiceTest {
 
     @Test
     void notifyPlayerGameStarted_sendsCorrectGameRoundDTO_success() {
-
-        User testUser = new User();
-        testUser.setId(1L);
-        testUser.setUsername("testUser");
 
         GameRoundDTO gameRoundDTO = new GameRoundDTO();
         gameRoundDTO.setGameSessionId(9L);
@@ -158,6 +173,44 @@ public class WsRoomServiceTest {
 
         assertThrows(ResponseStatusException.class, () ->
                 wsRoomService.notifyPlayerGameStarted(gameRoundDTO));
+    }
+
+    @Test
+    void notifyRoomPlayerLeft_hostIsLeaving_success() {
+        
+        Long roomId = testRoom.getRoomId();
+        boolean isHost = true;
+
+        wsRoomService.notifyRoomPlayerLeft(testUser, roomId, isHost);
+
+        verify(simpMessagingTemplate).convertAndSend(
+            eq("/topic/room/" + roomId), 
+            eq((Object) Map.of( 
+                "type", "ROOM_CLOSED",
+                "roomId", roomId.toString(),
+                "username", testUser.getUsername(),
+                "message", testUser.getUsername() + " closed the room. Room was deleted."
+            ))
+        );
+    }
+
+    @Test
+    void notifyRoomPlayerLeft_nonHostIsLeaving_success() {
+        
+        Long roomId = testRoom.getRoomId();
+        boolean isHost = false;
+
+        wsRoomService.notifyRoomPlayerLeft(testUser, roomId, isHost);
+
+        verify(simpMessagingTemplate).convertAndSend(
+            eq("/topic/room/" + roomId), 
+            eq((Object) Map.of( 
+                "type", "PLAYER_LEFT",
+                "roomId", roomId.toString(),
+                "username", testUser.getUsername(),
+                "message", testUser.getUsername() + " left the room. Room persists."
+            ))
+        );
     }
 }
 


### PR DESCRIPTION
- Implemented endpoint for leaving a room
- When the host leaves => room is deleted from database, client gets WS-message and has to inform other player that this room is not active anymore
- When non-host leaves => room persists, another player can join (as usual)