### PR TITLE
Shop implementation

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/constant/SabotageType.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/constant/SabotageType.java
@@ -1,0 +1,8 @@
+package ch.uzh.ifi.hase.soprafs26.constant;
+
+// When we add new items they need to be defined here!
+public enum SabotageType {
+    SQUID_INK_SABOTAGE,
+    JITTER_SABOTAGE,
+    ROTATE_SABOTAGE
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/GameController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/GameController.java
@@ -54,8 +54,10 @@ public class GameController {
     @ResponseStatus(HttpStatus.OK)
     public void purchaseSabotage(
             @PathVariable Long gameSessionId,
+            @RequestHeader(value = "token", required = false) String token,
             @RequestBody SabotagePostDTO sabotagePostDTO) {
         
+        userService.verifyToken(token);
         gameService.purchaseSabotage(gameSessionId, sabotagePostDTO);
     }
     

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/GameController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/GameController.java
@@ -1,6 +1,7 @@
 package ch.uzh.ifi.hase.soprafs26.controller;
 
 import ch.uzh.ifi.hase.soprafs26.rest.dto.GameRoundDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.SabotagePostDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.SkipPostDTO;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -47,6 +48,15 @@ public class GameController {
         return gameService.skipProblem(gameSessionId, problemId, skipPostDTO.getPlayerSessionId())
                           .map(ResponseEntity::ok)
                           .orElse(ResponseEntity.noContent().build());
+    }
+
+    @PostMapping("/games/{gameSessionId}/sabotage")
+    @ResponseStatus(HttpStatus.OK)
+    public void purchaseSabotage(
+            @PathVariable Long gameSessionId,
+            @RequestBody SabotagePostDTO sabotagePostDTO) {
+        
+        gameService.purchaseSabotage(gameSessionId, sabotagePostDTO);
     }
     
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/PlayerSession.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/PlayerSession.java
@@ -60,6 +60,8 @@ public class PlayerSession implements Serializable {
     inverseJoinColumns = @JoinColumn(name = "submission_id"))
     private List<Submission> submissions = new ArrayList<>();
 
+    private LocalDateTime sabotageEndTime; // New field to track when the sabotage effect ends
+
     public Long getPlayerSessionId() {
         return playerSessionId;
     }
@@ -131,4 +133,13 @@ public class PlayerSession implements Serializable {
     public void setSubmissions(List<Submission> submissions) {
         this.submissions = submissions;
     }
+
+    public LocalDateTime getSabotageEndTime() {
+        return sabotageEndTime;
+    }
+
+    public void setSabotageEndTime(LocalDateTime sabotageEndTime) {
+        this.sabotageEndTime = sabotageEndTime;
+    }
+
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Submission.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Submission.java
@@ -62,6 +62,9 @@ public class Submission implements Serializable { // Careful submission doesn't 
     @Column(nullable = true, columnDefinition = "TEXT")
     private String judgeTokensJson;
 
+    @Column(nullable = false)
+    private boolean pointsAwarded = false;
+
 
     @Column(nullable = false, columnDefinition = "TEXT")
     private String judgeResultJson; // For the user to debug
@@ -196,6 +199,13 @@ public class Submission implements Serializable { // Careful submission doesn't 
     public void setJudgeResultsJson(String judgeResultsJson) {
         this.judgeResultJson = judgeResultsJson;
     }
-  
+
+    public boolean isPointsAwarded() {
+        return pointsAwarded;
+    }
+
+    public void setPointsAwarded(boolean pointsAwarded) {
+        this.pointsAwarded = pointsAwarded;
+    }
 
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/User.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/User.java
@@ -68,6 +68,9 @@ public class User implements Serializable {
 	@Transient //@Transient means field is not persistent, it is simply defined and used to ad hoc rank players (no need to store in db)
 	private Integer rank;
 
+	@Column(nullable = false)
+	private int coins = 0;
+
 	public Long getId() {
 		return id;
 	}
@@ -178,5 +181,13 @@ public class User implements Serializable {
 
 	public void setAvatarId(int avatarId) {
 		this.avatarId = avatarId;
+	}
+
+	public int getCoins() {
+		return coins;
+	}
+
+	public void setCoins(int coins) {
+		this.coins = coins;
 	}
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/SabotageMessageDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/SabotageMessageDTO.java
@@ -1,0 +1,18 @@
+package ch.uzh.ifi.hase.soprafs26.rest.dto;
+import ch.uzh.ifi.hase.soprafs26.constant.SabotageType;
+
+public class SabotageMessageDTO {
+    private SabotageType item;
+
+    public SabotageMessageDTO(SabotageType item) {
+        this.item = item;
+    }
+
+    public SabotageType getItem() { 
+        return item; 
+    }
+    
+    public void setItem(SabotageType item) { 
+        this.item = item; 
+    }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/SabotagePostDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/SabotagePostDTO.java
@@ -1,0 +1,25 @@
+package ch.uzh.ifi.hase.soprafs26.rest.dto;
+import ch.uzh.ifi.hase.soprafs26.constant.SabotageType;
+
+// Frontend will send this to the backend when a player uses a sabotage item, so that the backend can process the sabotage and broadcast the effects to all players in the game session.
+public class SabotagePostDTO {
+    
+    private Long playerSessionId;
+    private SabotageType item; // e.g., "SQUID_INK_SABOTAGE", "JITTER_SABOTAGE", "ROTATE_SABOTAGE"
+
+    public Long getPlayerSessionId() { 
+        return playerSessionId; 
+    }
+    
+    public void setPlayerSessionId(Long playerSessionId) { 
+        this.playerSessionId = playerSessionId;
+ }
+    
+    public SabotageType getItem() { 
+        return item; 
+    }
+
+    public void setItem(SabotageType item) { 
+        this.item = item; 
+    }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/CodeExecutionService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/CodeExecutionService.java
@@ -26,6 +26,8 @@ import ch.uzh.ifi.hase.soprafs26.rest.dto.JudgeRequestDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.JudgeResultDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.JudgeTokenDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.TestCaseFeedbackDTO;
+import ch.uzh.ifi.hase.soprafs26.repository.UserRepository;
+import ch.uzh.ifi.hase.soprafs26.entity.User;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.http.HttpStatus;
@@ -51,6 +53,7 @@ public class CodeExecutionService {
     private final PlayerSessionRepository playerSessionRepository;
     private final GameSessionRepository gameSessionRepository;
     private final GameService gameService;
+    private final UserRepository userRepository;
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     /**
@@ -70,7 +73,8 @@ public class CodeExecutionService {
             PlayerSessionRepository playerSessionRepository,
             GameService gameService, 
             WsGameService wsGameService,
-            GameSessionRepository gameSessionRepository
+            GameSessionRepository gameSessionRepository,
+            UserRepository userRepository
     ) {
         this.problemService = problemService;
         this.judgeService = judgeService;
@@ -79,6 +83,7 @@ public class CodeExecutionService {
         this.gameService = gameService;
         this.wsGameService = wsGameService;
         this.gameSessionRepository = gameSessionRepository;
+        this.userRepository = userRepository;
     }
 
     public CodeRunDTO runCode(Long gameSessionId,
@@ -900,6 +905,15 @@ public class CodeExecutionService {
         playerSession.setCurrentScore(playerSession.getCurrentScore() + achievedPoints);
         playerSessionRepository.save(playerSession);
         playerSessionRepository.flush();
+
+        /*  NEW: Immediately update the User's overall points and coins!
+         *  So the user can instantly then use the earned coins.
+         */ 
+        User user = playerSession.getPlayer();
+        user.setCoins(user.getCoins() + achievedPoints);
+        user.setTotalPoints(user.getTotalPoints() + achievedPoints);
+        userRepository.save(user);
+        userRepository.flush();
 
     }
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/CodeExecutionService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/CodeExecutionService.java
@@ -895,6 +895,11 @@ public class CodeExecutionService {
     //awards the points won during a single Game Session (total points across all games updated at end of game)
     private void awardPoints(Submission submission) {
 
+        // Idempotency guard: skip if points have already been awarded for this submission
+        if (submission.isPointsAwarded()) {
+            return;
+        }
+
         PlayerSession playerSession = playerSessionRepository.findByPlayerSessionId(submission.getPlayerSessionId());
         if (playerSession == null) { //this is already checked before, hence, it should work
             throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Submission has no associated PlayerSession!");
@@ -908,12 +913,17 @@ public class CodeExecutionService {
 
         /*  NEW: Immediately update the User's overall points and coins!
          *  So the user can instantly then use the earned coins.
-         */ 
+         */
         User user = playerSession.getPlayer();
         user.setCoins(user.getCoins() + achievedPoints);
         user.setTotalPoints(user.getTotalPoints() + achievedPoints);
         userRepository.save(user);
         userRepository.flush();
+
+        // Mark points as awarded after all operations succeed to avoid a stale flag on failure
+        submission.setPointsAwarded(true);
+        submissionRepository.save(submission);
+        submissionRepository.flush();
 
     }
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/GameService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/GameService.java
@@ -442,6 +442,7 @@ public class GameService {
 
         userRepository.save(buyer);
         playerSessionRepository.save(opponentSession);
+        playerSessionRepository.flush();
         
         // 6) Broadcast the attack to the opponent via WebSocket
         wsGameService.sendSabotage(opponentSession.getPlayer().getUsername(), dto.getItem());

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/GameService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/GameService.java
@@ -444,7 +444,7 @@ public class GameService {
         playerSessionRepository.save(opponentSession);
         
         // 6) Broadcast the attack to the opponent via WebSocket
-        wsGameService.sendSabotage(opponentSession.getPlayer().getId(), dto.getItem());
+        wsGameService.sendSabotage(opponentSession.getPlayer().getUsername(), dto.getItem());
     }
 
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/GameService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/GameService.java
@@ -44,6 +44,7 @@ import ch.uzh.ifi.hase.soprafs26.rest.dto.GameSessionSampleSolutionsDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.GameTimeWarningDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.PlayerGameSummaryDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.PlayerScoreDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.SabotagePostDTO;
 import jakarta.transaction.Transactional;
 
 @Service
@@ -227,7 +228,8 @@ public class GameService {
         // add game session results to user profile
         for (PlayerSession ps : playerSessions) {
             User user = ps.getPlayer();
-            user.setTotalPoints(user.getTotalPoints() + ps.getCurrentScore());
+
+            // user.setTotalPoints(user.getTotalPoints() + ps.getCurrentScore()); COMMENTED TO AVOID DUPLICATE POINTS GIVEN, SINCE WE WILL NOW GIVE THE COINS DIRECTLY in CodeExecutionService
             user.setTotalGamesPlayed(user.getTotalGamesPlayed() + 1);
 
             if (!tie && winner != null && winner.getPlayer().getId().equals(user.getId())) {
@@ -402,6 +404,49 @@ public class GameService {
         
 
     }
+
+    public void purchaseSabotage(Long gameSessionId, SabotagePostDTO dto) {
+        // 1) Validate the buyer's session
+        PlayerSession buyerSession = playerSessionRepository.findByPlayerSessionId(dto.getPlayerSessionId());
+        if (buyerSession == null || !buyerSession.getGameSession().getGameSessionId().equals(gameSessionId)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid Player Session or Game Session!");
+        }
+
+        GameSession gameSession = buyerSession.getGameSession();
+        if (gameSession.getGameStatus() != GameStatus.ACTIVE) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "Game is not active!");
+        }
+
+        // 2) Find the opponent (since it's 1v1, it's the other player in the session)
+        PlayerSession opponentSession = gameSession.getPlayerSessions().stream()
+                .filter(ps -> !ps.getPlayerSessionId().equals(buyerSession.getPlayerSessionId()))
+                .findFirst()
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Opponent not found!"));
+
+        // 3) Check Buyer's Coin Balance
+        User buyer = buyerSession.getPlayer();
+        int itemPrice = 5; // TO ADJUST IF NEEDED!!
+        
+        if (buyer.getCoins() < itemPrice) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Not enough coins!");
+        }
+
+        // 4) Check if the opponent is already sabotaged
+        if (opponentSession.getSabotageEndTime() != null && opponentSession.getSabotageEndTime().isAfter(LocalDateTime.now())) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "Opponent is currently already sabotaged!");
+        }
+
+        // 5) Execute Transaction
+        buyer.setCoins(buyer.getCoins() - itemPrice);
+        opponentSession.setSabotageEndTime(LocalDateTime.now().plusSeconds(10));
+
+        userRepository.save(buyer);
+        playerSessionRepository.save(opponentSession);
+        
+        // 6) Broadcast the attack to the opponent via WebSocket
+        wsGameService.sendSabotage(opponentSession.getPlayer().getId(), dto.getItem());
+    }
+
 }
 
 // https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/concurrent/ScheduledFuture.html

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/WsGameService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/WsGameService.java
@@ -76,13 +76,12 @@ public class WsGameService {
         log.info("playerGameSummaryDTO sent to: {}", player.getUsername());
     }
 
-    public void sendSabotage(Long opponentUserId, SabotageType item) {
-        User opponent = userService.getUserById(opponentUserId);
+    public void sendSabotage(String opponentUsername, SabotageType item) {
         SabotageMessageDTO message = new SabotageMessageDTO(item);
         // Spring routes this to /user/{opponentUsername}/queue/sabotage
         simpMessagingTemplate.convertAndSendToUser(
-            opponent.getUsername(), 
-            "/queue/sabotage", 
+            opponentUsername,
+            "/queue/sabotage",
             message
         );
     }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/WsGameService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/WsGameService.java
@@ -10,6 +10,8 @@ import ch.uzh.ifi.hase.soprafs26.rest.dto.GameEndDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.GamePointsUpdateDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.GameTimeWarningDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.PlayerGameSummaryDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.SabotageMessageDTO;
+import ch.uzh.ifi.hase.soprafs26.constant.SabotageType;
 
 @Service
 public class WsGameService {
@@ -73,4 +75,15 @@ public class WsGameService {
         );
         log.info("playerGameSummaryDTO sent to: {}", player.getUsername());
     }
+
+    public void sendSabotage(Long opponentUserId, SabotageType item) {
+        SabotageMessageDTO message = new SabotageMessageDTO(item);
+        // Spring routes this to /user/{opponentUserId}/queue/sabotage
+        simpMessagingTemplate.convertAndSendToUser(
+            opponentUserId.toString(), 
+            "/queue/sabotage", 
+            message
+        );
+    }
+
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/WsGameService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/WsGameService.java
@@ -77,10 +77,11 @@ public class WsGameService {
     }
 
     public void sendSabotage(Long opponentUserId, SabotageType item) {
+        User opponent = userService.getUserById(opponentUserId);
         SabotageMessageDTO message = new SabotageMessageDTO(item);
-        // Spring routes this to /user/{opponentUserId}/queue/sabotage
+        // Spring routes this to /user/{opponentUsername}/queue/sabotage
         simpMessagingTemplate.convertAndSendToUser(
-            opponentUserId.toString(), 
+            opponent.getUsername(), 
             "/queue/sabotage", 
             message
         );

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/CodeExecutionServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/CodeExecutionServiceTest.java
@@ -17,6 +17,7 @@ import ch.uzh.ifi.hase.soprafs26.entity.User;
 import ch.uzh.ifi.hase.soprafs26.repository.GameSessionRepository;
 import ch.uzh.ifi.hase.soprafs26.repository.PlayerSessionRepository;
 import ch.uzh.ifi.hase.soprafs26.repository.SubmissionRepository;
+import ch.uzh.ifi.hase.soprafs26.repository.UserRepository;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.CodeExecutionPostDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.CodeRunDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.GameRoundDTO;
@@ -64,6 +65,9 @@ class CodeExecutionServiceTest {
     @Mock
     private WsGameService wsGameService;
 
+    @Mock
+    private UserRepository userRepository;
+
     @InjectMocks
     private CodeExecutionService codeExecutionService;
 
@@ -89,7 +93,8 @@ class CodeExecutionServiceTest {
             playerSessionRepository,
             gameService,
             wsGameService,
-            gameSessionRepository
+            gameSessionRepository,
+            userRepository
         );
 
         gameHost = new User();

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/CodeExecutionServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/CodeExecutionServiceTest.java
@@ -889,6 +889,37 @@ class CodeExecutionServiceTest {
         assertEquals(submission.getPassedTestCases() * POINTS_PER_TEST_CASE + 25, savedPlayerSession.getCurrentScore()); //player has 50 points now
     }
 
+    //getLatestSubmissionResult: points already awarded - skips awarding again (idempotency)
+    @Test
+    void getLatestSubmissionResult_pointsAlreadyAwarded_skipsAward() {
+
+        testGameSession.getProblems().add(p1);
+        playerSession1.setGameSession(testGameSession);
+        playerSession1.setCurrentScore(10);
+        Long playerSessionId = playerSession1.getPlayerSessionId();
+
+        Submission submission = new Submission();
+        submission.setGameSessionId(testGameSession.getGameSessionId());
+        submission.setProblemId(p1.getProblemId());
+        submission.setPlayerSessionId(playerSessionId);
+        submission.setStatus(SubmissionStatus.FINISHED);
+        submission.setPassedTestCases(5);
+        submission.setPointsAwarded(true); // points already awarded on a previous poll
+
+        when(playerSessionRepository.findByPlayerSessionId(playerSessionId)).thenReturn(playerSession1);
+        when(problemService.getProblemById(p1.getProblemId())).thenReturn(p1);
+        when(submissionRepository.findTopByGameSessionIdAndProblemIdAndPlayerSessionIdAndTypeOrderBySubmissionIdDesc(
+                testGameSession.getGameSessionId(), p1.getProblemId(), playerSessionId, SubmissionType.SUBMIT)).thenReturn(submission);
+
+        codeExecutionService.getLatestSubmissionResult(testGameSession.getGameSessionId(), p1.getProblemId(), playerSessionId);
+
+        // Score must remain unchanged because points were already awarded
+        assertEquals(10, playerSession1.getCurrentScore());
+        // Both save calls inside awardPoints must be skipped when the guard exits early
+        verify(submissionRepository, never()).save(submission);
+        verify(playerSessionRepository, never()).save(playerSession1);
+    }
+
     //getLatestSubmissionResult: last problem should end the game
     @Test
     void getLatestSubmissionResult_lastProblem_endsGameAndReturnsEmpty() {

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/GameServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/GameServiceTest.java
@@ -500,7 +500,7 @@ class GameServiceTest {
     }
 
     //player stats are updated in user profile
-    @Test 
+    @Test
     void endGameSession_updatesEachPlayersGameStats() {
 
         //players already have points
@@ -521,12 +521,14 @@ class GameServiceTest {
         gameService.endGameSession(gs, GameEndReason.PLAYER_FINISHED);
 
         assertEquals(21, gameHost.getTotalGamesPlayed());
-        assertEquals(101, gameHost.getTotalPoints().intValue());
+        // POINTS SHOULD NO LONGER UPDATE HERE - EXPECT 100, bcs we wanted to avoid duplicate point updates
+        assertEquals(100, gameHost.getTotalPoints().intValue()); 
         assertEquals(10, gameHost.getWinCount());
         assertTrue((gameHost.getWinRatePercentage() < ((double) 10 / 20 * 100))); //since host did not win
 
         assertEquals(41, player2.getTotalGamesPlayed());
-        assertEquals(108, player2.getTotalPoints().intValue());
+        // POINTS SHOULD NO LONGER UPDATE HERE - EXPECT 100, bcs we wanted to avoid duplicate point updates
+        assertEquals(100, player2.getTotalPoints().intValue()); 
         assertEquals(11, player2.getWinCount());
         assertTrue(player2.getWinRatePercentage() > ((double) 10 / 40 * 100)); //since player 2 did win
     }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/GameServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/GameServiceTest.java
@@ -530,7 +530,7 @@ class GameServiceTest {
         // POINTS SHOULD NO LONGER UPDATE HERE - EXPECT 100, bcs we wanted to avoid duplicate point updates
         assertEquals(100, player2.getTotalPoints().intValue()); 
         assertEquals(11, player2.getWinCount());
-        assertTrue(player2.getWinRatePercentage() > ((double) 10 / 40 * 100)); //since player 2 did win
+        assertTrue(player2.getWinRatePercentage() > ((double) 10 / 40 * 100)); //since player 2 did win 
     }
 
     //game stats update is actually saved and flushed


### PR DESCRIPTION
Feature: RealtimeSabotage Shop with coins

Database changes:

    Added coins (int) to User entity to track spendable currency.

    Added sabotageEndTime (LocalDateTime) to PlayerSession to track 10-second immunity and prevent overlapping attacks.

Point logic changes:

    Real-time scoring: Shifted point/coin allocation from the end of the game (GameService.endGameSession) to mid-game (CodeExecutionService.awardPoints). Users now earn coins immediately upon solving a problem. This means that during the game people will amass coins and be able to buy items, this will make the game much more lively and fun.


Websocket changes:

    Added REST Endpoint: POST /games/{gameSessionId}/sabotage handles the purchase transaction securely. It validates the buyer's funds, verifies the target isn't currently being sabotaged already (if yes we need to wait) then it deducts coins, and grants the target a 10-second "immunity" window.

    Added WebSocket Broadcast: If the REST purchase succeeds, the server immediately pushes a WebSocket message to the victim's private queue (/user/queue/sabotage) containing the SabotageType. This is such that in the frontend we can display to the opponent that an item was used, this will prevent the opponent from being confused when e.g the screen gets inked etc.
----------------------------------------------------------------------------------------------------------------------------------------
**Relevant for frontend (FE)**:


A. Buying an Item (REST)

    Endpoint: POST /games/{gameSessionId}/sabotage

    Request Body:
    JSON

    { // The item names are enums in constant ->SabotageType
      "playerSessionId": 123, 
      "item": "SQUID_INK_SABOTAGE" // Or JITTER_SABOTAGE, ROTATE_SABOTAGE
    }

    Handling Responses:

        200 OK: Purchase successful! (You can deduct the coin visually on the frontend).

        400 Bad Request: User doesn't have enough coins.

        409 Conflict: The opponent is currently immune (already under a sabotage effect).

B. Getting Attacked (WebSockets)
Subscribe to: /user/queue/sabotage
Incoming Payload:

JSON

    {
      "item": "SQUID_INK_SABOTAGE"
    }
    ```
*   **Frontend Logic Required:**
    1. When this message is received, set a React state: `setActiveSabotage(message.item)`.
    2. **CRITICAL:** Immediately trigger a `setTimeout` to clear it after 10 seconds: `setTimeout(() => setActiveSabotage(null), 10000);` (Ensure you handle cleanup if the component unmounts).
    3. Render the visual effects based on `activeSabotage`.

------------------------------------------------------------------------- 
**ITEMS (FE)**:
Each item will cost 5 coins (we can change this) and the **effect of all items is 10 seconds long! Since it's 10 seconds we might not want it to be too extreme and annoying.**

Item effects feel free to do it your way, I just gave some implementation examples in case):
- SQUID_INK_SABOTAGE (like in Mario Kart): Make an image of the mario kart squid appear and then ink the screen

- JITTER_SABOTAGE: This should make the code editor jitter up and down (as if it's trembling). Perhaps something like this:"
 ```@keyframes` shake {
  0% { transform: translate(1px, 1px) rotate(0deg); }
  10% { transform: translate(-1px, -2px) rotate(-1deg); }
  /* add a few more rapid keyframes */
  100% { transform: translate(1px, -2px) rotate(-1deg); }
} ...```"

- ROTATE_SABOTAGE: I thought somehing like 180 degrees but maybe thats just unplayable, we could also do like 45 degrees or something like that. 

A small tutorial in the lobby which explains the shop would be helpful

