### PR TITLE
Updated registration to use FE avatarId and added username uniqueness

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/UserController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/UserController.java
@@ -114,6 +114,14 @@ public class UserController {
 							@RequestHeader(value = "token", required = false)  String token) {
 		userService.changeAvatar(avatarId, userId, token);
 	}
+
+    @GetMapping("/users/check/{username}")
+    @ResponseStatus(HttpStatus.OK)
+    public void checkUsername(@PathVariable("username") String username) {
+
+        userService.verifyUsernameIsUnique(username);
+    }
+
 }
 
 // trigger docker build 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/UserPostDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/UserPostDTO.java
@@ -8,6 +8,8 @@ public class UserPostDTO {
 
 	private String bio;
 
+    private String avatarId;
+
 	public String getUsername() {
 		return username;
 	}
@@ -32,5 +34,12 @@ public class UserPostDTO {
 		this.bio = bio;
 	}
 
+    public String getAvatarId() {
+        return avatarId;
+    }
+
+    public void setAvatarId(String avatarId) {
+        this.avatarId = avatarId;
+    }
 	
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapper.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapper.java
@@ -36,6 +36,7 @@ public interface DTOMapper {
 	@Mapping(source = "username", target = "username")
 	@Mapping(source = "password", target = "password")
 	@Mapping(source = "bio", target = "bio")
+    @Mapping(source = "avatarId", target = "avatarId")
 	User convertUserPostDTOtoEntity(UserPostDTO userPostDTO);
 
 	@Mapping(source = "id", target = "id")

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/UserService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/UserService.java
@@ -67,9 +67,6 @@ public class UserService {
 
 		initialiseGameStats(newUser);
 
-		//generate random avatarId (goes from 1-10)
-		newUser.setAvatarId(new Random().nextInt(10) + 1);
-
 		// saves the given entity but data is only persisted in the database once
 		// flush() is called
 		newUser = userRepository.save(newUser);
@@ -244,5 +241,15 @@ public class UserService {
 		userRepository.save(user);
 		userRepository.flush();
 		log.debug("Successfully changed avatar for User: {}", user);
-	}	
+	}
+
+    public void verifyUsernameIsUnique(String username) {
+        checkIfUsernameIsValid(username);
+
+        User userByUsername = userRepository.findByUsername(username);
+        if (userByUsername != null) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT,
+                    "The username provided is already taken!");
+        }
+    }
 }


### PR DESCRIPTION
### Backend: Support for FE Avatar Selection & Validation

Updates the registration logic to handle frontend-sent avatar IDs and adds a dedicated uniqueness check.

### Changes
- **Registration:** Updated `createUser` to persist `avatarId` from FE.  Removed random avatarId generation.
- **New Endpoint:** Added `GET /users/check/{username}` (returns 200/409) for real-time FE validation.
- **Validation:** Centralized username uniqueness checks in `UserService`.

**Note:** This provides the necessary API support for the new registration flow in the frontend.