### PR TITLE
Updated registration to use FE avatarId

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/UserController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/UserController.java
@@ -114,6 +114,14 @@ public class UserController {
 							@RequestHeader(value = "token", required = false)  String token) {
 		userService.changeAvatar(avatarId, userId, token);
 	}
+
+    @GetMapping("/users/check/{username}")
+    @ResponseStatus(HttpStatus.OK)
+    public void checkUsername(@PathVariable("username") String username) {
+
+        userService.verifyUsernameIsUnique(username);
+    }
+
 }
 
 // trigger docker build 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/UserPostDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/UserPostDTO.java
@@ -8,6 +8,8 @@ public class UserPostDTO {
 
 	private String bio;
 
+    private String avatarId;
+
 	public String getUsername() {
 		return username;
 	}
@@ -32,5 +34,12 @@ public class UserPostDTO {
 		this.bio = bio;
 	}
 
+    public String getAvatarId() {
+        return avatarId;
+    }
+
+    public void setAvatarId(String avatarId) {
+        this.avatarId = avatarId;
+    }
 	
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/UserPostDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/UserPostDTO.java
@@ -8,7 +8,7 @@ public class UserPostDTO {
 
 	private String bio;
 
-    private String avatarId;
+    private int avatarId;
 
 	public String getUsername() {
 		return username;
@@ -34,12 +34,12 @@ public class UserPostDTO {
 		this.bio = bio;
 	}
 
-    public String getAvatarId() {
+    public int getAvatarId() {
         return avatarId;
     }
 
-    public void setAvatarId(String avatarId) {
+    public void setAvatarId(int avatarId) {
         this.avatarId = avatarId;
     }
-	
+
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapper.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapper.java
@@ -36,6 +36,7 @@ public interface DTOMapper {
 	@Mapping(source = "username", target = "username")
 	@Mapping(source = "password", target = "password")
 	@Mapping(source = "bio", target = "bio")
+    @Mapping(source = "avatarId", target = "avatarId")
 	User convertUserPostDTOtoEntity(UserPostDTO userPostDTO);
 
 	@Mapping(source = "id", target = "id")

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/UserService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/UserService.java
@@ -67,9 +67,6 @@ public class UserService {
 
 		initialiseGameStats(newUser);
 
-		//generate random avatarId (goes from 1-10)
-		newUser.setAvatarId(new Random().nextInt(10) + 1);
-
 		// saves the given entity but data is only persisted in the database once
 		// flush() is called
 		newUser = userRepository.save(newUser);
@@ -244,5 +241,15 @@ public class UserService {
 		userRepository.save(user);
 		userRepository.flush();
 		log.debug("Successfully changed avatar for User: {}", user);
-	}	
+	}
+
+    public void verifyUsernameIsUnique(String username) {
+        checkIfUsernameIsValid(username);
+
+        User userByUsername = userRepository.findByUsername(username);
+        if (userByUsername != null) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT,
+                    "The username provided is already taken!");
+        }
+    }
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/UserServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/UserServiceTest.java
@@ -42,6 +42,7 @@ class UserServiceTest {
 		testUser.setId(1L);
 		testUser.setUsername("testUsername");
 		testUser.setPassword("testPassword");
+        testUser.setAvatarId(5);
 
 		// when -> any object is being save in the userRepository -> return the dummy
 		// testUser
@@ -61,7 +62,7 @@ class UserServiceTest {
 		assertEquals(testUser.getUsername(), createdUser.getUsername());
 		assertEquals(testUser.getPassword(), createdUser.getPassword());
 		assertNotNull(createdUser.getToken());
-		assertTrue(createdUser.getAvatarId() >= 1 && createdUser.getAvatarId() <= 10);
+        assertEquals(testUser.getAvatarId(), createdUser.getAvatarId());
 		assertEquals(UserStatus.ONLINE, createdUser.getStatus());
 		assertEquals(0, createdUser.getWinCount());
 		assertEquals(0.0, createdUser.getWinRatePercentage());


### PR DESCRIPTION
### Backend: Support for FE Avatar Selection & Validation

Updates the registration logic to handle frontend-sent avatar IDs and adds another endpoint + logic for username uniqueness check (required for FE, CheckIfUserExists was insufficient because it requires a whole user and I only want to check it through the username before we proceed to the avatar selection part.  

### Changes
- **Registration:** Updated `createUser` to persist `avatarId` from FE.  Removed random avatarId generation.
- **New Endpoint:** Added `GET /users/check/{username}` (returns 200/409) for real-time username validation for FE.
- **Validation:** Centralized username uniqueness checks in `UserService`.

**Note:** This provides the necessary API support for the new registration flow in the frontend.