### PR TITLE
Feature/221 room chat

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/WsRoomController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/WsRoomController.java
@@ -1,20 +1,30 @@
 package ch.uzh.ifi.hase.soprafs26.controller;
 
+import java.security.Principal;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageExceptionHandler;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Controller;
 
 import ch.uzh.ifi.hase.soprafs26.service.WsRoomService;
 import ch.uzh.ifi.hase.soprafs26.websocket.dto.RoomMessageDTO;
+import ch.uzh.ifi.hase.soprafs26.websocket.dto.RoomChatMessageDTO;
 
 @Controller //handles+processes STOMP messages and delegates to wsRoomService that forwards to correct destination
 public class WsRoomController {
 
     private final WsRoomService wsRoomService;
+    private final SimpMessagingTemplate simpMessagingTemplate;
+    private final Logger log = LoggerFactory.getLogger(WsRoomController.class);
 
-    public WsRoomController(WsRoomService wsRoomService) {
+    public WsRoomController(WsRoomService wsRoomService, SimpMessagingTemplate simpMessagingTemplate) {
         this.wsRoomService = wsRoomService;
+        this.simpMessagingTemplate = simpMessagingTemplate;
     }
     
     @MessageMapping("/room/{roomId}/join") //listens to any STOMP-message sent to '/room/{roomId}/join' and invokes method 'joinRoom'
@@ -32,4 +42,23 @@ public class WsRoomController {
         );
     }
     //IMPORTANT: Method 'joinRoom' expects payload of type {username: "test1", host: true}
+
+    @MessageMapping("/room/{roomId}/send")
+    public void sendMessageToRoom(@DestinationVariable Long roomId, @Payload RoomChatMessageDTO roomChatMessageDTO){
+
+        wsRoomService.sendRoomChatMessage(roomId, roomChatMessageDTO);
+
+    }
+
+    //Needed for sending informative error messages (regarding chat messages) back to the client!
+    @MessageExceptionHandler
+    public void handleException(Exception ex, Principal principal) {
+        log.info("Principal=" + principal.getName() + " gets the following error: " + ex.getMessage());
+        simpMessagingTemplate.convertAndSendToUser(
+            principal.getName(),
+            "/queue/errors",
+            ex.getMessage()
+        );
+        log.info("Error message was sent!");
+    }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/WsRoomService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/WsRoomService.java
@@ -1,5 +1,6 @@
 package ch.uzh.ifi.hase.soprafs26.service;
 
+import java.time.LocalDateTime;
 import java.util.Map;
 
 import org.slf4j.Logger;
@@ -7,19 +8,28 @@ import org.slf4j.LoggerFactory;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 
+import ch.uzh.ifi.hase.soprafs26.entity.Room;
 import ch.uzh.ifi.hase.soprafs26.entity.User;
+import ch.uzh.ifi.hase.soprafs26.repository.RoomRepository;
+import ch.uzh.ifi.hase.soprafs26.repository.UserRepository;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.GameRoundDTO;
+import ch.uzh.ifi.hase.soprafs26.websocket.dto.RoomChatMessageDTO;
+import jakarta.transaction.Transactional;
 
 @Service
 public class WsRoomService {
 
     private final SimpMessagingTemplate simpMessagingTemplate;
     private final UserService userService;
-    private final Logger log = LoggerFactory.getLogger(UserService.class);
+    private final UserRepository userRepository;
+    private final RoomRepository roomRepository;
+    private final Logger log = LoggerFactory.getLogger(WsRoomService.class);
 
-    public WsRoomService(SimpMessagingTemplate simpMessagingTemplate, UserService userService) {
+    public WsRoomService(SimpMessagingTemplate simpMessagingTemplate, UserService userService, UserRepository userRepository, RoomRepository roomRepository) {
         this.simpMessagingTemplate = simpMessagingTemplate;
         this.userService = userService;
+        this.userRepository = userRepository;
+        this.roomRepository = roomRepository;
     }
 
     public void notifyPlayerJoinedRoom(Long roomId, String username, boolean isHost) {
@@ -62,5 +72,41 @@ public class WsRoomService {
         
         log.info("Sending room-wide info to roomId=" + roomId);
         simpMessagingTemplate.convertAndSend("/topic/room/" + roomId, notification);
+    }
+
+    @Transactional
+    public void sendRoomChatMessage(Long roomId, RoomChatMessageDTO roomChatMessageDTO) {
+        log.info("Received message with content: " + roomChatMessageDTO.getContent() + " from: " + roomChatMessageDTO.getSenderUsername());
+        validateRoomChatMessage(roomId, roomChatMessageDTO);
+
+        roomChatMessageDTO.setTimestamp(LocalDateTime.now());
+
+        simpMessagingTemplate.convertAndSend("/topic/chat/room/" + roomId, roomChatMessageDTO);
+        log.info("Received message was sent back to roomId=" + roomId);
+
+    }
+
+    private void validateRoomChatMessage(Long roomId, RoomChatMessageDTO roomChatMessageDTO){
+
+        Room room = roomRepository.findByRoomId(roomId);
+        if (room == null) {
+            throw new IllegalArgumentException("Invalid roomId!");
+        }
+
+        User sender = userRepository.findByUsername(roomChatMessageDTO.getSenderUsername());
+        if (sender == null) {
+            throw new IllegalArgumentException("Sender with given username not found!");
+        }
+        else if (!room.getPlayerIds().contains(sender.getId())) {
+            throw new IllegalArgumentException("Sender not allowed to send messages in this room!");
+        }
+
+        String message = roomChatMessageDTO.getContent();
+        if(message == null || message.isBlank()){
+			throw new IllegalArgumentException("Message is invalid: Messages cannot be empty or contain only spaces!");
+		}
+		else if (message.length() > 255) {
+			throw new IllegalArgumentException("Message is invalid: Messages cannot exceed 255 characters!");
+		}
     }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/websocket/dto/RoomChatMessageDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/websocket/dto/RoomChatMessageDTO.java
@@ -1,0 +1,29 @@
+package ch.uzh.ifi.hase.soprafs26.websocket.dto;
+
+import java.time.LocalDateTime;
+
+public class RoomChatMessageDTO {
+    
+    private String senderUsername;
+    private String content;
+    private LocalDateTime timestamp;
+
+    public String getSenderUsername() {
+        return senderUsername;
+    }
+    public void setSenderUsername(String senderUsername) {
+        this.senderUsername = senderUsername;
+    }
+    public String getContent() {
+        return content;
+    }
+    public void setContent(String content) {
+        this.content = content;
+    }
+    public LocalDateTime getTimestamp() {
+        return timestamp;
+    }
+    public void setTimestamp(LocalDateTime timestamp) {
+        this.timestamp = timestamp;
+    }
+}

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/WsRoomControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/WsRoomControllerTest.java
@@ -1,15 +1,23 @@
 package ch.uzh.ifi.hase.soprafs26.controller;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import java.security.Principal;
+
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 
+import ch.uzh.ifi.hase.soprafs26.entity.Room;
 import ch.uzh.ifi.hase.soprafs26.service.WsRoomService;
+import ch.uzh.ifi.hase.soprafs26.websocket.dto.RoomChatMessageDTO;
 import ch.uzh.ifi.hase.soprafs26.websocket.dto.RoomMessageDTO;
 
 
@@ -19,28 +27,64 @@ public class WsRoomControllerTest {
     @Mock
     private WsRoomService wsRoomService;
 
+    @Mock
+    private SimpMessagingTemplate simpMessagingTemplate;
+
     @InjectMocks
     private WsRoomController wsRoomController;
+
+    private RoomMessageDTO roomMessageDTO;
+    private Room testRoom;
+    private RoomChatMessageDTO roomChatMessageDTO;
+
+    @BeforeEach
+    void setup() {
+        roomMessageDTO = new RoomMessageDTO();
+        roomMessageDTO.setUsername("testUser");
+        roomMessageDTO.setIsHost(true);
+
+        testRoom = new Room();
+        testRoom.setRoomId(1L);
+
+        roomChatMessageDTO = new RoomChatMessageDTO();
+        roomChatMessageDTO.setSenderUsername("testUser");
+        roomChatMessageDTO.setContent("hello world");
+    }
 
     @Test //tests correct delegation to wsRoomService
     void joinRoom_delegateNotificationToService() {
 
-        RoomMessageDTO roomMessageDTO = new RoomMessageDTO();
-        roomMessageDTO.setUsername("testUser");
-        roomMessageDTO.setIsHost(true);
-        
         wsRoomController.joinRoom(1L, roomMessageDTO);
         
-        verify(wsRoomService).notifyPlayerJoinedRoom(1L, roomMessageDTO.getUsername(), roomMessageDTO.isHost());
+        verify(wsRoomService, times(1)).notifyPlayerJoinedRoom(1L, roomMessageDTO.getUsername(), roomMessageDTO.isHost());
     }
 
     @Test //tests throws error when roomId is null
     void joinRoom_roomIdIsNull_throwsException() {
 
-        RoomMessageDTO roomMessageDTO = new RoomMessageDTO();
-        roomMessageDTO.setUsername("testUser");
-        roomMessageDTO.setIsHost(true);
-
         assertThrows(IllegalArgumentException.class, () -> wsRoomController.joinRoom(null, roomMessageDTO));
+    }
+
+    @Test
+    void sendMessageToRoom_delegateNotificationToService() {
+
+        wsRoomController.sendMessageToRoom(testRoom.getRoomId(), roomChatMessageDTO);
+        
+        verify(wsRoomService, times(1)).sendRoomChatMessage(testRoom.getRoomId(), roomChatMessageDTO);
+    }
+
+    @Test
+    void handleException_sendsErrorToUser() {
+        String username = "testUser";
+        Principal mockPrincipal = () -> username;
+        
+        String errorReason = "Invalid roomId!";
+        wsRoomController.handleException(new IllegalArgumentException(errorReason), mockPrincipal);
+
+        verify(simpMessagingTemplate, times(1)).convertAndSendToUser(
+            eq(username),
+            eq("/queue/errors"),
+            eq(errorReason)
+        );
     }
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/WsRoomServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/WsRoomServiceTest.java
@@ -1,12 +1,14 @@
 package ch.uzh.ifi.hase.soprafs26.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.util.Map;
+import java.util.Set;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -22,7 +24,10 @@ import org.springframework.web.server.ResponseStatusException;
 
 import ch.uzh.ifi.hase.soprafs26.entity.Room;
 import ch.uzh.ifi.hase.soprafs26.entity.User;
+import ch.uzh.ifi.hase.soprafs26.repository.RoomRepository;
+import ch.uzh.ifi.hase.soprafs26.repository.UserRepository;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.GameRoundDTO;
+import ch.uzh.ifi.hase.soprafs26.websocket.dto.RoomChatMessageDTO;
 
 @ExtendWith(MockitoExtension.class)
 public class WsRoomServiceTest {
@@ -33,12 +38,19 @@ public class WsRoomServiceTest {
     @Mock
     UserService userService;
 
+    @Mock
+    UserRepository userRepository;
+
+    @Mock
+    RoomRepository roomRepository;
+
     @InjectMocks
     private WsRoomService wsRoomService;
 
     private User testUser;
     private User testUser7;
     private Room testRoom;
+    private RoomChatMessageDTO roomChatMessageDTO;
 
     @BeforeEach
     void setup() {
@@ -55,6 +67,10 @@ public class WsRoomServiceTest {
 
         testRoom = new Room();
         testRoom.setRoomId(1L);
+
+        roomChatMessageDTO = new RoomChatMessageDTO();
+        roomChatMessageDTO.setSenderUsername("testUser");
+        roomChatMessageDTO.setContent("hello world");
     }
 
     @Test
@@ -211,6 +227,104 @@ public class WsRoomServiceTest {
                 "message", testUser.getUsername() + " left the room. Room persists."
             ))
         );
+    }
+
+    @Test
+    void sendRoomChatMessage_success() {
+
+        testRoom.setPlayerIds(Set.of(testUser.getId()));
+
+        Mockito.when(roomRepository.findByRoomId(Mockito.any())).thenReturn(testRoom);
+        Mockito.when(userRepository.findByUsername(Mockito.any())).thenReturn(testUser);
+
+        wsRoomService.sendRoomChatMessage(testRoom.getRoomId(), roomChatMessageDTO);
+
+        ArgumentCaptor<String> destinationCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<RoomChatMessageDTO> payloadCaptorRoomChatMessageDTO= ArgumentCaptor.forClass(RoomChatMessageDTO.class);
+
+        verify(simpMessagingTemplate, times(1)).convertAndSend(
+            destinationCaptor.capture(),
+            payloadCaptorRoomChatMessageDTO.capture()
+        );
+
+        assertEquals("/topic/chat/room/" + testRoom.getRoomId(), destinationCaptor.getValue());
+
+        RoomChatMessageDTO captured = payloadCaptorRoomChatMessageDTO.getValue();
+        assertEquals(roomChatMessageDTO.getContent(), captured.getContent());
+        assertEquals(roomChatMessageDTO.getSenderUsername(), captured.getSenderUsername());
+        assertNotNull(captured.getTimestamp());
+    }
+
+    @Test
+    void sendRoomChatMessage_invalidRoomId_throwsException() {
+
+        Mockito.when(roomRepository.findByRoomId(Mockito.any())).thenReturn(null);
+
+        assertThrows(IllegalArgumentException.class, () ->
+            wsRoomService.sendRoomChatMessage(testRoom.getRoomId(), roomChatMessageDTO));
+    }
+
+    @Test
+    void sendRoomChatMessage_invalidSender_throwsException() {
+
+        Mockito.when(roomRepository.findByRoomId(Mockito.any())).thenReturn(testRoom);
+        Mockito.when(userRepository.findByUsername(Mockito.any())).thenReturn(null);
+
+        assertThrows(IllegalArgumentException.class, () ->
+            wsRoomService.sendRoomChatMessage(testRoom.getRoomId(), roomChatMessageDTO));
+    }
+
+    @Test
+    void sendRoomChatMessage_senderNotInRoom_throwsException() {
+        
+        testRoom.setPlayerIds(Set.of(testUser7.getId()));
+
+        Mockito.when(roomRepository.findByRoomId(Mockito.any())).thenReturn(testRoom);
+        Mockito.when(userRepository.findByUsername(Mockito.any())).thenReturn(testUser);
+
+        assertThrows(IllegalArgumentException.class, () ->
+            wsRoomService.sendRoomChatMessage(testRoom.getRoomId(), roomChatMessageDTO));
+    }
+
+    @Test
+    void sendRoomChatMessage_blankMessage_throwsException() {
+
+        testRoom.setPlayerIds(Set.of(testUser.getId()));
+        roomChatMessageDTO.setContent("  ");
+
+        Mockito.when(roomRepository.findByRoomId(Mockito.any())).thenReturn(testRoom);
+        Mockito.when(userRepository.findByUsername(Mockito.any())).thenReturn(testUser);
+
+        assertThrows(IllegalArgumentException.class, () ->
+            wsRoomService.sendRoomChatMessage(testRoom.getRoomId(), roomChatMessageDTO));
+    }
+
+    @Test
+    void sendRoomChatMessage_emptyMessage_throwsException() {
+
+        testRoom.setPlayerIds(Set.of(testUser.getId()));
+        roomChatMessageDTO.setContent("");
+
+        Mockito.when(roomRepository.findByRoomId(Mockito.any())).thenReturn(testRoom);
+        Mockito.when(userRepository.findByUsername(Mockito.any())).thenReturn(testUser);
+
+        assertThrows(IllegalArgumentException.class, () ->
+            wsRoomService.sendRoomChatMessage(testRoom.getRoomId(), roomChatMessageDTO));
+    }
+
+    @Test
+    void sendRoomChatMessage_messageTooLong_throwsException() {
+
+        int charLimit = 255; 
+
+        testRoom.setPlayerIds(Set.of(testUser.getId()));
+        roomChatMessageDTO.setContent("a".repeat(charLimit+1));
+
+        Mockito.when(roomRepository.findByRoomId(Mockito.any())).thenReturn(testRoom);
+        Mockito.when(userRepository.findByUsername(Mockito.any())).thenReturn(testUser);
+
+        assertThrows(IllegalArgumentException.class, () ->
+            wsRoomService.sendRoomChatMessage(testRoom.getRoomId(), roomChatMessageDTO));
     }
 }
 


### PR DESCRIPTION
- Implemented WebSocket functionalities (& tests) needed for the in-room/lobby chat
- WebSocket Method `sendRoomChatMessage` is protected, i.e., it is verified whether the room actually exists and whether the user is actually in that room
- Also, the message itself is checked: currently it cannot be empty, blank or longer than 255 chars (we can change this)
- Further implemented a personalised error handling so that clients are informed if something went wrong regarding chatting

infos for frontend:
- chat message mapping: `app/room/{roomId}/send`
- ⁠personalised client errors: `user/queue/errors`