### PR TITLE
implemented #230 including tests, putting under review

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/GameService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/GameService.java
@@ -66,6 +66,7 @@ public class GameService {
     private final ProblemRepository problemRepository;
     private final WsRoomService wsRoomService;
     private final WsGameService wsGameService;
+    private final RoomService roomService;
 
     //needed such that gameSessionSampleSolutionsDTO is actually sent!
     @Lazy
@@ -82,7 +83,8 @@ public class GameService {
                         WsGameService wsGameService, 
                         TaskScheduler taskScheduler,
                         ProblemRepository problemRepository,
-                        PlayerSessionRepository playerSessionRepository) {
+                        PlayerSessionRepository playerSessionRepository,
+                        RoomService roomService) {
       
         this.roomRepository = roomRepository;
         this.userService = userService;
@@ -94,6 +96,7 @@ public class GameService {
         this.taskScheduler = taskScheduler;
         this.playerSessionRepository = playerSessionRepository;
         this.problemRepository = problemRepository;
+        this.roomService = roomService;
     }
 
     public void createGameSession(Long hostId, Long roomId){
@@ -114,6 +117,8 @@ public class GameService {
         else if (room.getCurrentNumPlayers() < 2){
             throw new ResponseStatusException(HttpStatus.CONFLICT, "Not enough players to start the game!");
         }
+
+        roomService.cancelLobbyTimer(roomId); 
         
         // 2. create game session + player sessions + extract problems
         

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/RoomService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/RoomService.java
@@ -2,6 +2,7 @@ package ch.uzh.ifi.hase.soprafs26.service;
 
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -16,24 +17,36 @@ import ch.uzh.ifi.hase.soprafs26.repository.RoomRepository;
 import ch.uzh.ifi.hase.soprafs26.repository.UserRepository;
 import jakarta.transaction.Transactional;
 
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledFuture;
+import org.springframework.scheduling.TaskScheduler;
+
 @Service
 @Transactional
 public class RoomService {
-    
+
+    private static final Duration lobbyTimeoutTime = Duration.ofMinutes(30);
+
     private final RoomRepository roomRepository;
     private final UserService userService;
     private final WsRoomService wsRoomService;
     private final ProblemRepository problemRepository;
+    private final TaskScheduler taskScheduler;
+    private final Map<Long, ScheduledFuture<?>> lobbyTimers = new ConcurrentHashMap<>();
 
     public RoomService(@Qualifier("roomRepository") RoomRepository roomRepository,
                                                     UserRepository userRepository,
                                                     UserService userService,
                                                     WsRoomService wsRoomService,
-                                                    ProblemRepository problemRepository) {
+                                                    ProblemRepository problemRepository,
+                                                    TaskScheduler taskScheduler) {
         this.roomRepository = roomRepository;
         this.userService = userService;
         this.wsRoomService = wsRoomService;
         this.problemRepository = problemRepository;
+        this.taskScheduler = taskScheduler;
     }
 
     public Room createRoom(Room roomInput, Long userId, String token) {
@@ -64,6 +77,8 @@ public class RoomService {
 
         Room createdRoom = roomRepository.save(roomInput);
         roomRepository.flush();
+
+        scheduleLobbyTimer(createdRoom.getRoomId());
 
         return createdRoom;
     }
@@ -116,6 +131,7 @@ public class RoomService {
 
         if (room.getHostUserId().equals(userId)){
             //host leaves => room deleted
+            cancelLobbyTimer(roomId);
             roomRepository.delete(room);
             roomRepository.flush();
 
@@ -160,6 +176,23 @@ public class RoomService {
         return allRooms.stream()
                        .filter(Room::isRoomOpen)
                        .toList();   
+    }
+
+    public void cancelLobbyTimer(Long roomId) {
+        ScheduledFuture<?> future = lobbyTimers.remove(roomId);
+        if (future != null) future.cancel(false);
+    }
+
+    private void scheduleLobbyTimer(Long roomId) {
+        ScheduledFuture<?> future = taskScheduler.schedule(() -> {
+            Room room = roomRepository.findByRoomId(roomId);
+            if (room == null || !room.isRoomOpen()) return;
+            room.setRoomOpen(false);
+            roomRepository.save(room);
+            roomRepository.flush();
+            wsRoomService.notifyRoomExpired(roomId);
+        }, Instant.now().plus(lobbyTimeoutTime));
+        lobbyTimers.put(roomId, future);
     }
 
     private String generateRoomCode() {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/WsRoomService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/WsRoomService.java
@@ -57,6 +57,15 @@ public class WsRoomService {
         log.info("GameRoundDTO sent to: {}", player.getUsername());
     }
 
+    public void notifyRoomExpired(Long roomId) {
+        Map<String, String> notification = Map.of(
+            "type", "ROOM_EXPIRED",
+            "roomId", roomId.toString(),
+            "message", "Lobby closed due to inactivity."
+        );
+        simpMessagingTemplate.convertAndSend("/topic/room/" + roomId, notification);
+    }
+
     public void notifyRoomPlayerLeft(User user, Long roomId, Boolean isHost){
         String username = user.getUsername();
 

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/GameServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/GameServiceTest.java
@@ -102,6 +102,9 @@ class GameServiceTest {
     private ProblemRepository problemRepository;
 
     @Mock
+    private RoomService roomService;
+
+    @Mock
     private ScheduledFuture<Object> warningFuture;
 
     @Mock
@@ -1107,6 +1110,38 @@ class GameServiceTest {
 
         assertEquals(HttpStatus.CONFLICT, exception.getStatusCode());
         assertEquals("Game is not active!", exception.getReason());
+    }
+
+    // starting a game cancels the room's pending lobby timer
+    @Test
+    void createGameSession_validInputs_cancelsLobbyTimer() {
+        Problem p1 = new Problem();
+        p1.setProblemId(1L);
+        Problem p3 = new Problem();
+        p3.setProblemId(3L);
+        Problem p7 = new Problem();
+        p7.setProblemId(7L);
+
+        testRoom.setNumOfProblems(3);
+
+        given(roomRepository.findByRoomId(testRoom.getRoomId())).willReturn(testRoom);
+        given(userRepository.findUserById(gameHost.getId())).willReturn(gameHost);
+        given(problemRepository.findAllByGameLanguageAndGameDifficulty(Mockito.any(), Mockito.any())).willReturn(List.of(p1, p3, p7));
+        given(userService.getUserById(gameHost.getId())).willReturn(gameHost);
+        given(userService.getUserById(player2.getId())).willReturn(player2);
+        given(gameSessionRepository.save(any(GameSession.class)))
+            .willAnswer(invocation -> {
+                GameSession s = invocation.getArgument(0);
+                s.setGameSessionId(99L);
+                return s;
+            });
+        given(taskScheduler.schedule(any(Runnable.class), any(Instant.class)))
+            .willReturn((ScheduledFuture) warningFuture, (ScheduledFuture) endFuture);
+        doNothing().when(wsRoomService).notifyPlayerGameStarted(Mockito.any());
+
+        gameService.createGameSession(gameHost.getId(), testRoom.getRoomId());
+
+        verify(roomService, times(1)).cancelLobbyTimer(testRoom.getRoomId());
     }
 
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/RoomServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/RoomServiceTest.java
@@ -3,9 +3,11 @@ package ch.uzh.ifi.hase.soprafs26.service;
 
 import ch.uzh.ifi.hase.soprafs26.entity.User; // <- ensure this is the correct User type
 
+import java.time.Instant;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ScheduledFuture;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.doNothing;
@@ -17,10 +19,12 @@ import static org.mockito.BDDMockito.given;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
+import org.springframework.scheduling.TaskScheduler;
 import org.springframework.web.server.ResponseStatusException;
 import org.springframework.http.HttpStatus;
 
@@ -34,6 +38,7 @@ import ch.uzh.ifi.hase.soprafs26.constant.GameDifficulty;
 import ch.uzh.ifi.hase.soprafs26.constant.GameLanguage;
 import ch.uzh.ifi.hase.soprafs26.constant.GameMode;
 
+@SuppressWarnings({"unchecked", "rawtypes"})
 class RoomServiceTest {
 
     @Mock
@@ -50,6 +55,12 @@ class RoomServiceTest {
 
     @Mock
     private ProblemRepository problemRepository;
+
+    @Mock
+    private TaskScheduler taskScheduler;
+
+    @Mock
+    private ScheduledFuture scheduledFuture;
 
     @InjectMocks
     private RoomService roomService;
@@ -108,6 +119,8 @@ class RoomServiceTest {
             room.setRoomId(1L);
             return room;
         }); //returns same object that was passed in to avoid nullpointer exception
+        Mockito.when(taskScheduler.schedule(Mockito.any(Runnable.class), Mockito.any(Instant.class)))
+            .thenReturn((ScheduledFuture) scheduledFuture);
 
         Room createdRoom = roomService.createRoom(DTOMapper.INSTANCE.convertRoomPostDTOtoEntity(roomPostDTO), host.getId(), "validToken");
         
@@ -452,7 +465,7 @@ class RoomServiceTest {
     //leave room, user not even in room to leave
     @Test
     void leaveRoom_playerNotInRoom_throwsForbidden() {
-        
+
         doNothing().when(userService).verifyTokenAndUserId(testUser.getToken(), testUser.getId());
         given(roomRepository.findByRoomId(testRoom.getRoomId())).willReturn(testRoom);
 
@@ -462,6 +475,188 @@ class RoomServiceTest {
         });
 
         assertEquals(HttpStatus.FORBIDDEN, exception.getStatusCode());
+    }
+
+    // lobby timer is scheduled when room is created
+    @Test
+    void createRoom_validInput_schedulesLobbyTimer() {
+        User host = new User();
+        host.setId(1L);
+        host.setUsername("hostUser");
+
+        RoomPostDTO roomPostDTO = new RoomPostDTO();
+        roomPostDTO.setGameDifficulty(GameDifficulty.EASY);
+        roomPostDTO.setGameLanguage(GameLanguage.PYTHON);
+        roomPostDTO.setGameMode(GameMode.RACE);
+
+        Mockito.when(userService.getUserbyId(host.getId())).thenReturn(host);
+        Mockito.when(roomRepository.save(Mockito.any(Room.class))).thenAnswer(invocation -> {
+            Room room = invocation.getArgument(0);
+            room.setRoomId(1L);
+            return room;
+        });
+        Mockito.when(taskScheduler.schedule(Mockito.any(Runnable.class), Mockito.any(Instant.class)))
+            .thenReturn((ScheduledFuture) scheduledFuture);
+
+        roomService.createRoom(DTOMapper.INSTANCE.convertRoomPostDTOtoEntity(roomPostDTO), host.getId(), "validToken");
+
+        verify(taskScheduler, times(1)).schedule(Mockito.any(Runnable.class), Mockito.any(Instant.class));
+    }
+
+    // lobby timer fires: open room gets closed and WS notification is sent
+    @Test
+    void lobbyTimer_openRoom_closesRoomAndNotifies() {
+        User host = new User();
+        host.setId(1L);
+        host.setUsername("hostUser");
+
+        RoomPostDTO roomPostDTO = new RoomPostDTO();
+        roomPostDTO.setGameDifficulty(GameDifficulty.EASY);
+        roomPostDTO.setGameLanguage(GameLanguage.PYTHON);
+        roomPostDTO.setGameMode(GameMode.RACE);
+
+        Mockito.when(userService.getUserbyId(host.getId())).thenReturn(host);
+        Mockito.when(roomRepository.save(Mockito.any(Room.class))).thenAnswer(invocation -> {
+            Room room = invocation.getArgument(0);
+            room.setRoomId(1L);
+            return room;
+        });
+
+        ArgumentCaptor<Runnable> runnableCaptor = ArgumentCaptor.forClass(Runnable.class);
+        Mockito.when(taskScheduler.schedule(runnableCaptor.capture(), Mockito.any(Instant.class)))
+            .thenReturn((ScheduledFuture) scheduledFuture);
+
+        roomService.createRoom(DTOMapper.INSTANCE.convertRoomPostDTOtoEntity(roomPostDTO), host.getId(), "validToken");
+
+        // reset invocation counts so we only assert what the timer callback does, not createRoom()
+        Mockito.clearInvocations(roomRepository, wsRoomService);
+
+        Room openRoom = new Room();
+        openRoom.setRoomId(1L);
+        openRoom.setRoomOpen(true);
+        Mockito.when(roomRepository.findByRoomId(1L)).thenReturn(openRoom);
+
+        runnableCaptor.getValue().run();
+
+        assertFalse(openRoom.isRoomOpen());
+        verify(roomRepository, times(1)).save(openRoom);
+        verify(roomRepository, times(1)).flush();
+        verify(wsRoomService, times(1)).notifyRoomExpired(1L);
+    }
+
+    // lobby timer fires: room already closed (player joined), does nothing
+    @Test
+    void lobbyTimer_alreadyClosedRoom_doesNothing() {
+        User host = new User();
+        host.setId(1L);
+
+        RoomPostDTO roomPostDTO = new RoomPostDTO();
+        roomPostDTO.setGameDifficulty(GameDifficulty.EASY);
+        roomPostDTO.setGameLanguage(GameLanguage.PYTHON);
+        roomPostDTO.setGameMode(GameMode.RACE);
+
+        Mockito.when(userService.getUserbyId(host.getId())).thenReturn(host);
+        Mockito.when(roomRepository.save(Mockito.any(Room.class))).thenAnswer(invocation -> {
+            Room room = invocation.getArgument(0);
+            room.setRoomId(1L);
+            return room;
+        });
+
+        ArgumentCaptor<Runnable> runnableCaptor = ArgumentCaptor.forClass(Runnable.class);
+        Mockito.when(taskScheduler.schedule(runnableCaptor.capture(), Mockito.any(Instant.class)))
+            .thenReturn((ScheduledFuture) scheduledFuture);
+
+        roomService.createRoom(DTOMapper.INSTANCE.convertRoomPostDTOtoEntity(roomPostDTO), host.getId(), "validToken");
+
+        // reset invocation counts so we only assert what the timer callback does, not createRoom()
+        Mockito.clearInvocations(roomRepository, wsRoomService);
+
+        Room closedRoom = new Room();
+        closedRoom.setRoomId(1L);
+        closedRoom.setRoomOpen(false);
+        Mockito.when(roomRepository.findByRoomId(1L)).thenReturn(closedRoom);
+
+        runnableCaptor.getValue().run();
+
+        verify(roomRepository, times(0)).save(closedRoom);
+        verify(wsRoomService, times(0)).notifyRoomExpired(Mockito.any());
+    }
+
+    // lobby timer fires: room was already deleted (game started and host left), does nothing
+    @Test
+    void lobbyTimer_roomNotFound_doesNothing() {
+        User host = new User();
+        host.setId(1L);
+
+        RoomPostDTO roomPostDTO = new RoomPostDTO();
+        roomPostDTO.setGameDifficulty(GameDifficulty.EASY);
+        roomPostDTO.setGameLanguage(GameLanguage.PYTHON);
+        roomPostDTO.setGameMode(GameMode.RACE);
+
+        Mockito.when(userService.getUserbyId(host.getId())).thenReturn(host);
+        Mockito.when(roomRepository.save(Mockito.any(Room.class))).thenAnswer(invocation -> {
+            Room room = invocation.getArgument(0);
+            room.setRoomId(1L);
+            return room;
+        });
+
+        ArgumentCaptor<Runnable> runnableCaptor = ArgumentCaptor.forClass(Runnable.class);
+        Mockito.when(taskScheduler.schedule(runnableCaptor.capture(), Mockito.any(Instant.class)))
+            .thenReturn((ScheduledFuture) scheduledFuture);
+
+        roomService.createRoom(DTOMapper.INSTANCE.convertRoomPostDTOtoEntity(roomPostDTO), host.getId(), "validToken");
+
+        // reset invocation counts so we only assert what the timer callback does, not createRoom()
+        Mockito.clearInvocations(roomRepository, wsRoomService);
+
+        Mockito.when(roomRepository.findByRoomId(1L)).thenReturn(null);
+
+        runnableCaptor.getValue().run();
+
+        verify(roomRepository, times(0)).save(Mockito.any());
+        verify(wsRoomService, times(0)).notifyRoomExpired(Mockito.any());
+    }
+
+    // host leaving cancels the pending lobby timer
+    @Test
+    void leaveRoom_hostLeaves_cancelsLobbyTimer() {
+        User host = new User();
+        host.setId(1L);
+        host.setUsername("hostUser");
+        host.setToken("hostToken");
+
+        RoomPostDTO roomPostDTO = new RoomPostDTO();
+        roomPostDTO.setGameDifficulty(GameDifficulty.EASY);
+        roomPostDTO.setGameLanguage(GameLanguage.PYTHON);
+        roomPostDTO.setGameMode(GameMode.RACE);
+
+        Mockito.when(userService.getUserbyId(host.getId())).thenReturn(host);
+        Mockito.when(roomRepository.save(Mockito.any(Room.class))).thenAnswer(invocation -> {
+            Room room = invocation.getArgument(0);
+            room.setRoomId(1L);
+            return room;
+        });
+        Mockito.when(taskScheduler.schedule(Mockito.any(Runnable.class), Mockito.any(Instant.class)))
+            .thenReturn((ScheduledFuture) scheduledFuture);
+
+        roomService.createRoom(DTOMapper.INSTANCE.convertRoomPostDTOtoEntity(roomPostDTO), host.getId(), "hostToken");
+
+        Room room = new Room();
+        room.setRoomId(1L);
+        Set<Long> playerIds = new HashSet<>();
+        playerIds.add(host.getId());
+        room.setPlayerIds(playerIds);
+        room.setHostUserId(host.getId());
+
+        doNothing().when(userService).verifyTokenAndUserId("hostToken", host.getId());
+        Mockito.when(roomRepository.findByRoomId(1L)).thenReturn(room);
+        Mockito.when(userService.getUserById(host.getId())).thenReturn(host);
+        doNothing().when(wsRoomService).notifyRoomPlayerLeft(host, 1L, true);
+
+        roomService.leaveRoom(1L, host.getId(), "hostToken");
+
+        verify(scheduledFuture, times(1)).cancel(false);
+        verify(roomRepository, times(1)).delete(room);
     }
 
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/UserServiceIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/UserServiceIntegrationTest.java
@@ -1,5 +1,6 @@
 package ch.uzh.ifi.hase.soprafs26.service;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,6 +33,11 @@ class UserServiceIntegrationTest {
 
 	@BeforeEach
 	void setup() {
+		userRepository.deleteAll();
+	}
+
+	@AfterEach
+	void teardown() {
 		userRepository.deleteAll();
 	}
 

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/WsRoomServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/WsRoomServiceTest.java
@@ -315,7 +315,7 @@ public class WsRoomServiceTest {
     @Test
     void sendRoomChatMessage_messageTooLong_throwsException() {
 
-        int charLimit = 255; 
+        int charLimit = 255;
 
         testRoom.setPlayerIds(Set.of(testUser.getId()));
         roomChatMessageDTO.setContent("a".repeat(charLimit+1));
@@ -325,6 +325,23 @@ public class WsRoomServiceTest {
 
         assertThrows(IllegalArgumentException.class, () ->
             wsRoomService.sendRoomChatMessage(testRoom.getRoomId(), roomChatMessageDTO));
+    }
+
+    // notifyRoomExpired sends ROOM_EXPIRED event to the room topic
+    @Test
+    void notifyRoomExpired_success() {
+        Long roomId = testRoom.getRoomId();
+
+        wsRoomService.notifyRoomExpired(roomId);
+
+        verify(simpMessagingTemplate).convertAndSend(
+            eq("/topic/room/" + roomId),
+            eq((Object) Map.of(
+                "type", "ROOM_EXPIRED",
+                "roomId", roomId.toString(),
+                "message", "Lobby closed due to inactivity."
+            ))
+        );
     }
 }
 


### PR DESCRIPTION
#230: close idle lobbies after 30 minutes via scheduled task

  Schedules a one-shot timer on room creation that sets isRoomOpen=false
  and fires a ROOM_EXPIRED WS event if the lobby is still open when it fires.
  Timer is cancelled when the host manually leaves or a game is started.
  Also fixes a test isolation leak in UserServiceIntegrationTest.

  For FE:

  Subscribe to the existing room topic no new endpoint:
  /topic/room/{roomId}

  When the lobby times out this message is sent:
  {
    "type": "ROOM_EXPIRED",
    "roomId": "XY",
    "message": "Lobby closed due to inactivity."
  }

The room is not deleted, just closed (isRoomOpen = false), so it will no longer appear in the open rooms list. Timeout is 30 minutes from room creation.