### PR TITLE
Implemented the second gamemode, SPRINT_CLASSIC and SPRINT_ARCADE, co…

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/constant/GameMode.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/constant/GameMode.java
@@ -1,5 +1,5 @@
 package ch.uzh.ifi.hase.soprafs26.constant;
 
 public enum GameMode {
-    RACE, SPRINT;
+    SPRINT_CLASSIC, SPRINT_ARCADE;
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/CodeExecutionService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/CodeExecutionService.java
@@ -955,13 +955,15 @@ public class CodeExecutionService {
          *  So the user can instantly then use the earned coins.
          */
         GameMode gameMode = playerSession.getGameSession().getRoom().getGameMode();
+        
+        User user = playerSession.getPlayer();
         if (gameMode == GameMode.SPRINT_ARCADE) {
-            User user = playerSession.getPlayer();
             user.setCoins(user.getCoins() + achievedPoints);
-            user.setTotalPoints(user.getTotalPoints() + achievedPoints);
-            userRepository.save(user);
-            userRepository.flush();
         }
+        user.setTotalPoints(user.getTotalPoints() + achievedPoints);
+        userRepository.save(user);
+        userRepository.flush();
+        
 
         // Mark points as awarded after all operations succeed to avoid a stale flag on failure
         submission.setPointsAwarded(true);

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/CodeExecutionService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/CodeExecutionService.java
@@ -2,6 +2,7 @@ package ch.uzh.ifi.hase.soprafs26.service;
 
 import ch.uzh.ifi.hase.soprafs26.constant.GameEndReason;
 import ch.uzh.ifi.hase.soprafs26.constant.GameLanguage;
+import ch.uzh.ifi.hase.soprafs26.constant.GameMode;
 import ch.uzh.ifi.hase.soprafs26.constant.GameStatus;
 import ch.uzh.ifi.hase.soprafs26.constant.PlayerSessionStatus;
 import ch.uzh.ifi.hase.soprafs26.constant.SubmissionStatus;
@@ -953,11 +954,14 @@ public class CodeExecutionService {
         /*  NEW: Immediately update the User's overall points and coins!
          *  So the user can instantly then use the earned coins.
          */
-        User user = playerSession.getPlayer();
-        user.setCoins(user.getCoins() + achievedPoints);
-        user.setTotalPoints(user.getTotalPoints() + achievedPoints);
-        userRepository.save(user);
-        userRepository.flush();
+        GameMode gameMode = playerSession.getGameSession().getRoom().getGameMode();
+        if (gameMode == GameMode.SPRINT_ARCADE) {
+            User user = playerSession.getPlayer();
+            user.setCoins(user.getCoins() + achievedPoints);
+            user.setTotalPoints(user.getTotalPoints() + achievedPoints);
+            userRepository.save(user);
+            userRepository.flush();
+        }
 
         // Mark points as awarded after all operations succeed to avoid a stale flag on failure
         submission.setPointsAwarded(true);

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/GameService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/GameService.java
@@ -25,6 +25,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
 import ch.uzh.ifi.hase.soprafs26.constant.GameEndReason;
+import ch.uzh.ifi.hase.soprafs26.constant.GameMode;
 import ch.uzh.ifi.hase.soprafs26.constant.GameStatus;
 import ch.uzh.ifi.hase.soprafs26.constant.PlayerSessionStatus;
 import ch.uzh.ifi.hase.soprafs26.constant.Verdict;
@@ -245,6 +246,13 @@ public class GameService {
             userRepository.saveAndFlush(user);
         }
 
+        // reset coins after the game, coins are only per game!
+        for (PlayerSession ps : playerSessions) {
+            User user = ps.getPlayer();
+            user.setCoins(0);
+            userRepository.saveAndFlush(user);
+        }
+
         GameEndDTO gameEndDTO = new GameEndDTO();
         gameEndDTO.setGameSessionId(gameSession.getGameSessionId());
         gameEndDTO.setGameStatus(gameSession.getGameStatus());
@@ -422,6 +430,11 @@ public class GameService {
         GameSession gameSession = buyerSession.getGameSession();
         if (gameSession.getGameStatus() != GameStatus.ACTIVE) {
             throw new ResponseStatusException(HttpStatus.CONFLICT, "Game is not active!");
+        }
+
+        GameMode gameMode = gameSession.getRoom().getGameMode();
+        if (gameMode != GameMode.SPRINT_ARCADE) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Shop is not available in this game mode!");
         }
 
         // 2) Find the opponent (since it's 1v1, it's the other player in the session)

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/RoomControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/RoomControllerTest.java
@@ -75,7 +75,7 @@ class RoomControllerTest {
         room.setPlayerIds(new HashSet<>(Set.of(1L)));
         room.setGameDifficulty(GameDifficulty.EASY);
         room.setGameLanguage(GameLanguage.PYTHON);
-        room.setGameMode(GameMode.RACE);
+        room.setGameMode(GameMode.SPRINT_ARCADE);
         room.setMaxSkips(3);
         room.setTimeLimitSeconds(60);
         room.setNumOfProblems(10); 
@@ -83,7 +83,7 @@ class RoomControllerTest {
         RoomPostDTO roomPostDTO = new RoomPostDTO();
         roomPostDTO.setGameDifficulty(GameDifficulty.EASY);
         roomPostDTO.setGameLanguage(GameLanguage.PYTHON);
-        roomPostDTO.setGameMode(GameMode.RACE);
+        roomPostDTO.setGameMode(GameMode.SPRINT_ARCADE);
         roomPostDTO.setMaxSkips(3);
         roomPostDTO.setTimeLimitSeconds(60);
         roomPostDTO.setNumOfProblems(10);
@@ -127,12 +127,12 @@ class RoomControllerTest {
         room.setPlayerIds(new HashSet<>(Set.of(1L)));
         room.setGameDifficulty(GameDifficulty.EASY);
         room.setGameLanguage(GameLanguage.PYTHON);
-        room.setGameMode(GameMode.RACE);
+        room.setGameMode(GameMode.SPRINT_ARCADE);
 
         RoomPostDTO roomPostDTO = new RoomPostDTO();
         roomPostDTO.setGameDifficulty(GameDifficulty.EASY);
         roomPostDTO.setGameLanguage(GameLanguage.PYTHON);
-        roomPostDTO.setGameMode(GameMode.RACE);
+        roomPostDTO.setGameMode(GameMode.SPRINT_ARCADE);
         
         Mockito.when(roomService.createRoom(Mockito.any(), Mockito.anyLong(), Mockito.anyString())).thenReturn(room);
         
@@ -166,7 +166,7 @@ class RoomControllerTest {
         RoomPostDTO roomPostDTO = new RoomPostDTO();
         roomPostDTO.setGameDifficulty(GameDifficulty.HARD);
         roomPostDTO.setGameLanguage(GameLanguage.JAVA);
-        roomPostDTO.setGameMode(GameMode.SPRINT);
+        roomPostDTO.setGameMode(GameMode.SPRINT_CLASSIC);
         roomPostDTO.setMaxSkips(3);
         roomPostDTO.setTimeLimitSeconds(60);
         roomPostDTO.setNumOfProblems(10);
@@ -193,7 +193,7 @@ class RoomControllerTest {
         {
                 "gameDifficulty": "INVALID",
                 "gameLanguage": "PYTHON",
-                "gameMode": "SPRINT"
+                "gameMode": "SPRINT_CLASSIC"
         }
         """;
 
@@ -228,7 +228,7 @@ class RoomControllerTest {
         room.setPlayerIds(new HashSet<>(Set.of(1L, 5L)));
         room.setGameDifficulty(GameDifficulty.EASY);
         room.setGameLanguage(GameLanguage.PYTHON);
-        room.setGameMode(GameMode.RACE);
+        room.setGameMode(GameMode.SPRINT_ARCADE);
 
         User joiningUser = new User();
         joiningUser.setId(5L);
@@ -360,7 +360,7 @@ class RoomControllerTest {
                 room.setPlayerIds(new HashSet<>(Set.of(1L)));
                 room.setGameDifficulty(GameDifficulty.EASY);
                 room.setGameLanguage(GameLanguage.PYTHON);
-                room.setGameMode(GameMode.RACE);
+                room.setGameMode(GameMode.SPRINT_ARCADE);
                 room.setMaxSkips(3);
                 room.setTimeLimitSeconds(120);
                 room.setNumOfProblems(5);
@@ -439,7 +439,7 @@ class RoomControllerTest {
                 room1.setRoomOpen(true);
                 room1.setGameDifficulty(GameDifficulty.EASY);
                 room1.setGameLanguage(GameLanguage.PYTHON);
-                room1.setGameMode(GameMode.RACE);
+                room1.setGameMode(GameMode.SPRINT_ARCADE);
                 room1.setMaxSkips(3);
                 room1.setTimeLimitSeconds(120);
                 room1.setNumOfProblems(5);
@@ -453,7 +453,7 @@ class RoomControllerTest {
                 room2.setRoomOpen(true);
                 room2.setGameDifficulty(GameDifficulty.EASY);
                 room2.setGameLanguage(GameLanguage.PYTHON);
-                room2.setGameMode(GameMode.RACE);
+                room2.setGameMode(GameMode.SPRINT_ARCADE);
                 room2.setMaxSkips(3);
                 room2.setTimeLimitSeconds(180);
                 room2.setNumOfProblems(8);

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/RoomRestIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/RoomRestIntegrationTest.java
@@ -67,7 +67,7 @@ class RoomRestIntegrationTest {
                 .header("userId", host.getId())
                 .header("token", host.getToken())
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(roomBody(GameDifficulty.EASY, GameLanguage.PYTHON, GameMode.RACE)))
+                .content(roomBody(GameDifficulty.EASY, GameLanguage.PYTHON, GameMode.SPRINT_ARCADE)))
             .andExpect(status().isCreated())
             .andExpect(jsonPath("$.roomId").exists())
             .andExpect(jsonPath("$.roomJoinCode", matchesPattern("[A-F0-9]{6}")))
@@ -77,7 +77,7 @@ class RoomRestIntegrationTest {
             .andExpect(jsonPath("$.isRoomOpen").value(true))
             .andExpect(jsonPath("$.gameDifficulty").value("EASY"))
             .andExpect(jsonPath("$.gameLanguage").value("PYTHON"))
-            .andExpect(jsonPath("$.gameMode").value("RACE"));
+            .andExpect(jsonPath("$.gameMode").value("SPRINT_ARCADE"));
     }
 
     @Test
@@ -90,7 +90,7 @@ class RoomRestIntegrationTest {
                 .header("userId", host.getId())
                 .header("token", "invalidToken")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(roomBody(GameDifficulty.EASY, GameLanguage.PYTHON, GameMode.RACE)))
+                .content(roomBody(GameDifficulty.EASY, GameLanguage.PYTHON, GameMode.SPRINT_ARCADE)))
             .andExpect(status().isUnauthorized());
     }
 
@@ -102,7 +102,7 @@ class RoomRestIntegrationTest {
                 .header("userId", host.getId())
                 .header("token", host.getToken())
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(roomBody(GameDifficulty.EASY, GameLanguage.PYTHON, GameMode.RACE)))
+                .content(roomBody(GameDifficulty.EASY, GameLanguage.PYTHON, GameMode.SPRINT_ARCADE)))
             .andExpect(status().isCreated())
             .andReturn()
             .getResponse()

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/repository/PlayerSessionIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/repository/PlayerSessionIntegrationTest.java
@@ -56,7 +56,7 @@ public class PlayerSessionIntegrationTest {
         room.setHostUserId(1L);
         room.setGameDifficulty(GameDifficulty.EASY);
         room.setGameLanguage(GameLanguage.JAVA);
-        room.setGameMode(GameMode.RACE);
+        room.setGameMode(GameMode.SPRINT_ARCADE);
 
         roomRepository.save(room);
         roomRepository.flush();

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/repository/RoomRepositoryIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/repository/RoomRepositoryIntegrationTest.java
@@ -38,7 +38,7 @@ class RoomRepositoryIntegrationTest {
 		room.setPlayerIds(new HashSet<>(Set.of(1L)));
 		room.setGameDifficulty(GameDifficulty.HARD);
 		room.setGameLanguage(GameLanguage.JAVA);
-		room.setGameMode(GameMode.RACE);
+		room.setGameMode(GameMode.SPRINT_ARCADE);
 		room.setMaxSkips(2);
 		room.setTimeLimitSeconds(600);
 		room.setNumOfProblems(10);
@@ -77,7 +77,7 @@ class RoomRepositoryIntegrationTest {
 		room.setPlayerIds(new HashSet<>(Set.of(1L)));
 		room.setGameDifficulty(GameDifficulty.HARD);
 		room.setGameLanguage(GameLanguage.JAVA);
-		room.setGameMode(GameMode.RACE);
+		room.setGameMode(GameMode.SPRINT_ARCADE);
 		room.setMaxSkips(2);
 		room.setTimeLimitSeconds(600);
 		room.setNumOfProblems(10);
@@ -117,7 +117,7 @@ class RoomRepositoryIntegrationTest {
 		room.setPlayerIds(new HashSet<>(Set.of(1L))); //updatable
 		room.setGameDifficulty(GameDifficulty.EASY);
 		room.setGameLanguage(GameLanguage.PYTHON);
-		room.setGameMode(GameMode.SPRINT);
+		room.setGameMode(GameMode.SPRINT_CLASSIC);
 		room.setMaxSkips(2);
 		room.setTimeLimitSeconds(600);
 		room.setNumOfProblems(10);
@@ -134,7 +134,7 @@ class RoomRepositoryIntegrationTest {
 		savedRoom.setHostUserId(5432L);
 		savedRoom.setGameDifficulty(GameDifficulty.HARD);
 		savedRoom.setGameLanguage(GameLanguage.JAVA);
-		savedRoom.setGameMode(GameMode.RACE);
+		savedRoom.setGameMode(GameMode.SPRINT_ARCADE);
 		savedRoom.setMaxSkips(250);
 		savedRoom.setTimeLimitSeconds(24000);
 		savedRoom.setNumOfProblems(15000);
@@ -151,7 +151,7 @@ class RoomRepositoryIntegrationTest {
 		assertEquals(1L, roomToCheck.getHostUserId());
 		assertEquals(GameDifficulty.EASY, roomToCheck.getGameDifficulty());
 		assertEquals(GameLanguage.PYTHON, roomToCheck.getGameLanguage());
-		assertEquals(GameMode.SPRINT, roomToCheck.getGameMode());
+		assertEquals(GameMode.SPRINT_CLASSIC, roomToCheck.getGameMode());
 		assertEquals(2, roomToCheck.getMaxSkips());
 		assertEquals(600, roomToCheck.getTimeLimitSeconds());
 		assertEquals(10, roomToCheck.getNumOfProblems());

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapperTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapperTest.java
@@ -119,7 +119,7 @@ class DTOMapperTest {
         RoomPostDTO roomPostDTO = new RoomPostDTO();
         roomPostDTO.setGameDifficulty(GameDifficulty.EASY);
         roomPostDTO.setGameLanguage(GameLanguage.JAVA);
-        roomPostDTO.setGameMode(GameMode.SPRINT);
+        roomPostDTO.setGameMode(GameMode.SPRINT_CLASSIC);
         roomPostDTO.setMaxSkips(2);
         roomPostDTO.setTimeLimitSeconds(600);
         roomPostDTO.setNumOfProblems(3);
@@ -128,7 +128,7 @@ class DTOMapperTest {
 
         assertEquals("EASY", room.getGameDifficulty().toString());
         assertEquals("JAVA", room.getGameLanguage().toString());
-        assertEquals("SPRINT", room.getGameMode().toString());
+        assertEquals("SPRINT_CLASSIC", room.getGameMode().toString());
         assertEquals(2, room.getMaxSkips());
         assertEquals(600, room.getTimeLimitSeconds());
         assertEquals(3, room.getNumOfProblems());
@@ -146,7 +146,7 @@ class DTOMapperTest {
         room.setPlayerIds(Set.of(10L));
         room.setGameDifficulty(GameDifficulty.EASY);
         room.setGameLanguage(GameLanguage.JAVA);
-        room.setGameMode(GameMode.RACE);
+        room.setGameMode(GameMode.SPRINT_ARCADE);
         room.setMaxSkips(2);
         room.setTimeLimitSeconds(600);
         room.setNumOfProblems(3);
@@ -160,7 +160,7 @@ class DTOMapperTest {
         assertTrue(roomGetDTO.getIsRoomOpen());
         assertEquals("EASY", roomGetDTO.getGameDifficulty().toString());
 		assertEquals("JAVA", roomGetDTO.getGameLanguage().toString());
-		assertEquals("RACE", roomGetDTO.getGameMode().toString());
+		assertEquals("SPRINT_ARCADE", roomGetDTO.getGameMode().toString());
 		assertEquals(2, roomGetDTO.getMaxSkips());
 		assertEquals(600, roomGetDTO.getTimeLimitSeconds());
 		assertEquals(3, roomGetDTO.getNumOfProblems());
@@ -178,7 +178,7 @@ class DTOMapperTest {
         room.setPlayerIds(Set.of(10L));
         room.setGameDifficulty(GameDifficulty.HARD);
         room.setGameLanguage(GameLanguage.JAVA);
-        room.setGameMode(GameMode.SPRINT);
+        room.setGameMode(GameMode.SPRINT_CLASSIC);
         room.setMaxSkips(2);
         room.setTimeLimitSeconds(600);
         room.setNumOfProblems(3);
@@ -194,7 +194,7 @@ class DTOMapperTest {
         assertEquals(Set.of(10L), roomDTO.getPlayerIds());
         assertEquals("HARD", roomDTO.getGameDifficulty().toString());
 		assertEquals("JAVA", roomDTO.getGameLanguage().toString());
-		assertEquals("SPRINT", roomDTO.getGameMode().toString());
+		assertEquals("SPRINT_CLASSIC", roomDTO.getGameMode().toString());
 		assertEquals(2, roomDTO.getMaxSkips());
 		assertEquals(600, roomDTO.getTimeLimitSeconds());
 		assertEquals(3, roomDTO.getNumOfProblems());

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/CodeExecutionServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/CodeExecutionServiceTest.java
@@ -129,7 +129,7 @@ class CodeExecutionServiceTest {
         testRoom.setPlayerIds(playerIds);
         testRoom.setGameDifficulty(GameDifficulty.EASY);
         testRoom.setGameLanguage(GameLanguage.PYTHON);
-        testRoom.setGameMode(GameMode.RACE);
+        testRoom.setGameMode(GameMode.SPRINT_ARCADE);
         
         p1 = new Problem();
         p1.setProblemId(1L);
@@ -920,6 +920,65 @@ class CodeExecutionServiceTest {
         // Both save calls inside awardPoints must be skipped when the guard exits early
         verify(submissionRepository, never()).save(submission);
         verify(playerSessionRepository, never()).save(playerSession1);
+    }
+
+    //getLatestSubmissionResult: Sprint Arcade awards coins and totalPoints to the user
+    @Test
+    void getLatestSubmissionResult_sprintArcade_awardsCoinsAndTotalPoints() {
+        testGameSession.getProblems().add(p1);
+        playerSession1.setGameSession(testGameSession);
+        playerSession1.setCurrentScore(0);
+        gameHost.setCoins(0);
+        gameHost.setTotalPoints(0L);
+        Long playerSessionId = playerSession1.getPlayerSessionId();
+
+        Submission submission = new Submission();
+        submission.setGameSessionId(testGameSession.getGameSessionId());
+        submission.setProblemId(p1.getProblemId());
+        submission.setPlayerSessionId(playerSessionId);
+        submission.setStatus(SubmissionStatus.FINISHED);
+        submission.setPassedTestCases(3);
+
+        when(playerSessionRepository.findByPlayerSessionId(playerSessionId)).thenReturn(playerSession1);
+        when(problemService.getProblemById(p1.getProblemId())).thenReturn(p1);
+        when(submissionRepository.findTopByGameSessionIdAndProblemIdAndPlayerSessionIdAndTypeOrderBySubmissionIdDesc(
+                testGameSession.getGameSessionId(), p1.getProblemId(), playerSessionId, SubmissionType.SUBMIT)).thenReturn(submission);
+
+        codeExecutionService.getLatestSubmissionResult(testGameSession.getGameSessionId(), p1.getProblemId(), playerSessionId);
+
+        assertEquals(3, gameHost.getCoins()); // 3 test cases passed = 3 coins
+        assertEquals(3L, gameHost.getTotalPoints().longValue());
+        verify(userRepository, times(1)).save(gameHost);
+    }
+
+    //getLatestSubmissionResult: Sprint Classic does NOT award coins or totalPoints
+    @Test
+    void getLatestSubmissionResult_sprintClassic_doesNotAwardCoinsOrTotalPoints() {
+        testRoom.setGameMode(GameMode.SPRINT_CLASSIC);
+        testGameSession.getProblems().add(p1);
+        playerSession1.setGameSession(testGameSession);
+        playerSession1.setCurrentScore(0);
+        gameHost.setCoins(0);
+        gameHost.setTotalPoints(0L);
+        Long playerSessionId = playerSession1.getPlayerSessionId();
+
+        Submission submission = new Submission();
+        submission.setGameSessionId(testGameSession.getGameSessionId());
+        submission.setProblemId(p1.getProblemId());
+        submission.setPlayerSessionId(playerSessionId);
+        submission.setStatus(SubmissionStatus.FINISHED);
+        submission.setPassedTestCases(3);
+
+        when(playerSessionRepository.findByPlayerSessionId(playerSessionId)).thenReturn(playerSession1);
+        when(problemService.getProblemById(p1.getProblemId())).thenReturn(p1);
+        when(submissionRepository.findTopByGameSessionIdAndProblemIdAndPlayerSessionIdAndTypeOrderBySubmissionIdDesc(
+                testGameSession.getGameSessionId(), p1.getProblemId(), playerSessionId, SubmissionType.SUBMIT)).thenReturn(submission);
+
+        codeExecutionService.getLatestSubmissionResult(testGameSession.getGameSessionId(), p1.getProblemId(), playerSessionId);
+
+        assertEquals(0, gameHost.getCoins()); // Coins NOT awarded in Sprint Classic
+        assertEquals(0L, gameHost.getTotalPoints().longValue());
+        verify(userRepository, never()).save(any()); // No user save in Sprint Classic
     }
 
     //getLatestSubmissionResult: last problem should end the game

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/CodeExecutionServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/CodeExecutionServiceTest.java
@@ -951,9 +951,9 @@ class CodeExecutionServiceTest {
         verify(userRepository, times(1)).save(gameHost);
     }
 
-    //getLatestSubmissionResult: Sprint Classic does NOT award coins or totalPoints
+    //getLatestSubmissionResult: Sprint Classic awards totalPoints but NOT coins
     @Test
-    void getLatestSubmissionResult_sprintClassic_doesNotAwardCoinsOrTotalPoints() {
+    void getLatestSubmissionResult_sprintClassic_awardsPointsButNotCoins() {
         testRoom.setGameMode(GameMode.SPRINT_CLASSIC);
         testGameSession.getProblems().add(p1);
         playerSession1.setGameSession(testGameSession);
@@ -977,8 +977,8 @@ class CodeExecutionServiceTest {
         codeExecutionService.getLatestSubmissionResult(testGameSession.getGameSessionId(), p1.getProblemId(), playerSessionId);
 
         assertEquals(0, gameHost.getCoins()); // Coins NOT awarded in Sprint Classic
-        assertEquals(0L, gameHost.getTotalPoints().longValue());
-        verify(userRepository, never()).save(any()); // No user save in Sprint Classic
+        assertEquals(3L, gameHost.getTotalPoints().longValue()); // totalPoints ARE awarded in Sprint Classic
+        verify(userRepository, times(1)).save(gameHost); 
     }
 
     //getLatestSubmissionResult: last problem should end the game

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/CodeExecutionServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/CodeExecutionServiceTest.java
@@ -928,8 +928,8 @@ class CodeExecutionServiceTest {
         testGameSession.getProblems().add(p1);
         playerSession1.setGameSession(testGameSession);
         playerSession1.setCurrentScore(0);
-        gameHost.setCoins(0);
-        gameHost.setTotalPoints(0L);
+        gameHost.setCoins(7);
+        gameHost.setTotalPoints(10L);
         Long playerSessionId = playerSession1.getPlayerSessionId();
 
         Submission submission = new Submission();
@@ -946,8 +946,8 @@ class CodeExecutionServiceTest {
 
         codeExecutionService.getLatestSubmissionResult(testGameSession.getGameSessionId(), p1.getProblemId(), playerSessionId);
 
-        assertEquals(3, gameHost.getCoins()); // 3 test cases passed = 3 coins
-        assertEquals(3L, gameHost.getTotalPoints().longValue());
+        assertEquals(10, gameHost.getCoins()); // existing coins are increased by achieved points
+        assertEquals(13L, gameHost.getTotalPoints().longValue());
         verify(userRepository, times(1)).save(gameHost);
     }
 
@@ -958,8 +958,8 @@ class CodeExecutionServiceTest {
         testGameSession.getProblems().add(p1);
         playerSession1.setGameSession(testGameSession);
         playerSession1.setCurrentScore(0);
-        gameHost.setCoins(0);
-        gameHost.setTotalPoints(0L);
+        gameHost.setCoins(9);
+        gameHost.setTotalPoints(10L);
         Long playerSessionId = playerSession1.getPlayerSessionId();
 
         Submission submission = new Submission();
@@ -976,8 +976,8 @@ class CodeExecutionServiceTest {
 
         codeExecutionService.getLatestSubmissionResult(testGameSession.getGameSessionId(), p1.getProblemId(), playerSessionId);
 
-        assertEquals(0, gameHost.getCoins()); // Coins NOT awarded in Sprint Classic
-        assertEquals(3L, gameHost.getTotalPoints().longValue()); // totalPoints ARE awarded in Sprint Classic
+        assertEquals(9, gameHost.getCoins()); // Coins stay unchanged in Sprint Classic
+        assertEquals(13L, gameHost.getTotalPoints().longValue()); // totalPoints ARE awarded in Sprint Classic
         verify(userRepository, times(1)).save(gameHost); 
     }
 

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/GameServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/GameServiceTest.java
@@ -159,7 +159,7 @@ class GameServiceTest {
         testRoom.setPlayerIds(playerIds);
         testRoom.setGameDifficulty(GameDifficulty.EASY);
         testRoom.setGameLanguage(GameLanguage.PYTHON);
-        testRoom.setGameMode(GameMode.RACE);
+        testRoom.setGameMode(GameMode.SPRINT_ARCADE);
 
         given(gameSessionRepository.save(any(GameSession.class))).willAnswer(i -> i.getArgument(0));
     }
@@ -553,11 +553,28 @@ class GameServiceTest {
 
         gameService.endGameSession(gs, GameEndReason.PLAYER_FINISHED);
 
-        verify(userRepository, times(2)).saveAndFlush(any(User.class));
+        // 2 players × 2 saveAndFlush calls each (stats update + coin reset)
+        verify(userRepository, times(4)).saveAndFlush(any(User.class));
+    }
+
+    //coins are reset to 0 for all players when the game ends
+    @Test
+    void endGameSession_resetsCoinsToZeroForAllPlayers_success() {
+        gameHost.setCoins(30);
+        player2.setCoins(10);
+
+        PlayerSession ps1 = buildPlayerSession(1L, gameHost, 5, 2);
+        PlayerSession ps2 = buildPlayerSession(2L, player2, 3, 1);
+        GameSession gs = buildGameSession(99L, ps1, ps2);
+
+        gameService.endGameSession(gs, GameEndReason.PLAYER_FINISHED);
+
+        assertEquals(0, gameHost.getCoins());
+        assertEquals(0, player2.getCoins());
     }
 
     //gameSessionSampleSolution are included
-    @Test 
+    @Test
     void endGameSession_prepareGameSessionSampleSolutions_success() {
 
         Problem p1 = new Problem();
@@ -968,9 +985,13 @@ class GameServiceTest {
     @Test
     void purchaseSabotage_success_deductsCoinsAndLocksOpponent() {
         // 1. Setup Game Session
+        Room room = new Room();
+        room.setGameMode(GameMode.SPRINT_ARCADE);
+
         GameSession gameSession = new GameSession();
         gameSession.setGameSessionId(1L);
         gameSession.setGameStatus(GameStatus.ACTIVE);
+        gameSession.setRoom(room);
 
         // 2. Setup Buyer
         User buyer = new User();
@@ -1018,9 +1039,13 @@ class GameServiceTest {
 
     @Test
     void purchaseSabotage_insufficientCoins_throwsBadRequest() {
+        Room room = new Room();
+        room.setGameMode(GameMode.SPRINT_ARCADE);
+
         GameSession gameSession = new GameSession();
         gameSession.setGameSessionId(1L);
         gameSession.setGameStatus(GameStatus.ACTIVE);
+        gameSession.setRoom(room);
 
         User buyer = new User();
         buyer.setCoins(2); // Not enough coins!
@@ -1053,9 +1078,13 @@ class GameServiceTest {
 
     @Test
     void purchaseSabotage_opponentAlreadyImmune_throwsConflict() {
+        Room room = new Room();
+        room.setGameMode(GameMode.SPRINT_ARCADE);
+
         GameSession gameSession = new GameSession();
         gameSession.setGameSessionId(1L);
         gameSession.setGameStatus(GameStatus.ACTIVE);
+        gameSession.setRoom(room);
 
         User buyer = new User();
         buyer.setCoins(50); // Has plenty of coins
@@ -1110,6 +1139,44 @@ class GameServiceTest {
 
         assertEquals(HttpStatus.CONFLICT, exception.getStatusCode());
         assertEquals("Game is not active!", exception.getReason());
+    }
+
+    //shop is blocked in Sprint Classic - purchaseSabotage must throw 403 FORBIDDEN
+    @Test
+    void purchaseSabotage_sprintClassic_throwsForbidden() {
+        Room room = new Room();
+        room.setGameMode(GameMode.SPRINT_CLASSIC);
+
+        GameSession gameSession = new GameSession();
+        gameSession.setGameSessionId(1L);
+        gameSession.setGameStatus(GameStatus.ACTIVE);
+        gameSession.setRoom(room);
+
+        User buyer = new User();
+        buyer.setId(10L);
+        buyer.setCoins(20); // Has enough coins, but shop is blocked in Sprint Classic
+
+        PlayerSession buyerSession = new PlayerSession();
+        buyerSession.setPlayerSessionId(100L);
+        buyerSession.setPlayer(buyer);
+        buyerSession.setGameSession(gameSession);
+
+        gameSession.setPlayerSessions(List.of(buyerSession));
+
+        SabotagePostDTO dto = new SabotagePostDTO();
+        dto.setPlayerSessionId(100L);
+        dto.setItem(SabotageType.SQUID_INK_SABOTAGE);
+
+        when(playerSessionRepository.findByPlayerSessionId(100L)).thenReturn(buyerSession);
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class,
+            () -> gameService.purchaseSabotage(1L, dto));
+
+        assertEquals(HttpStatus.FORBIDDEN, exception.getStatusCode());
+        assertEquals("Shop is not available in this game mode!", exception.getReason());
+        assertEquals(20, buyer.getCoins()); // Coins NOT deducted
+        verify(userRepository, never()).save(any());
+        verify(wsGameService, never()).sendSabotage(any(), any());
     }
 
     // starting a game cancels the room's pending lobby timer

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/RoomServiceIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/RoomServiceIntegrationTest.java
@@ -45,7 +45,7 @@ class RoomServiceIntegrationTest {
         Room roomInput = new Room();
         roomInput.setGameDifficulty(GameDifficulty.EASY);
         roomInput.setGameLanguage(GameLanguage.PYTHON);
-        roomInput.setGameMode(GameMode.RACE);
+        roomInput.setGameMode(GameMode.SPRINT_ARCADE);
 
         // when
         Room room = roomService.createRoom(roomInput, createdHost.getId(), createdHost.getToken());
@@ -62,7 +62,7 @@ class RoomServiceIntegrationTest {
         assertTrue(roomDB.getPlayerIds().contains(createdHost.getId()));
         assertEquals(GameDifficulty.EASY, roomDB.getGameDifficulty());
         assertEquals(GameLanguage.PYTHON, roomDB.getGameLanguage());
-        assertEquals(GameMode.RACE, roomDB.getGameMode());
+        assertEquals(GameMode.SPRINT_ARCADE, roomDB.getGameMode());
     }
 
     @Test
@@ -76,7 +76,7 @@ class RoomServiceIntegrationTest {
         Room roomInput = new Room();
         roomInput.setGameDifficulty(GameDifficulty.EASY);
         roomInput.setGameLanguage(GameLanguage.PYTHON);
-        roomInput.setGameMode(GameMode.RACE);
+        roomInput.setGameMode(GameMode.SPRINT_ARCADE);
         Room created = roomService.createRoom(roomInput, host.getId(), host.getToken());
 
         // and a second registered user

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/RoomServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/RoomServiceTest.java
@@ -107,7 +107,7 @@ class RoomServiceTest {
         RoomPostDTO roomPostDTO = new RoomPostDTO();
         roomPostDTO.setGameDifficulty(GameDifficulty.EASY);
         roomPostDTO.setGameLanguage(GameLanguage.PYTHON);
-        roomPostDTO.setGameMode(GameMode.RACE);
+        roomPostDTO.setGameMode(GameMode.SPRINT_ARCADE);
         roomPostDTO.setMaxSkips(3);
         roomPostDTO.setTimeLimitSeconds(60);
         roomPostDTO.setNumOfProblems(null); //CHANGE THIS
@@ -487,7 +487,7 @@ class RoomServiceTest {
         RoomPostDTO roomPostDTO = new RoomPostDTO();
         roomPostDTO.setGameDifficulty(GameDifficulty.EASY);
         roomPostDTO.setGameLanguage(GameLanguage.PYTHON);
-        roomPostDTO.setGameMode(GameMode.RACE);
+        roomPostDTO.setGameMode(GameMode.SPRINT_ARCADE);
 
         Mockito.when(userService.getUserbyId(host.getId())).thenReturn(host);
         Mockito.when(roomRepository.save(Mockito.any(Room.class))).thenAnswer(invocation -> {
@@ -513,7 +513,7 @@ class RoomServiceTest {
         RoomPostDTO roomPostDTO = new RoomPostDTO();
         roomPostDTO.setGameDifficulty(GameDifficulty.EASY);
         roomPostDTO.setGameLanguage(GameLanguage.PYTHON);
-        roomPostDTO.setGameMode(GameMode.RACE);
+        roomPostDTO.setGameMode(GameMode.SPRINT_ARCADE);
 
         Mockito.when(userService.getUserbyId(host.getId())).thenReturn(host);
         Mockito.when(roomRepository.save(Mockito.any(Room.class))).thenAnswer(invocation -> {
@@ -553,7 +553,7 @@ class RoomServiceTest {
         RoomPostDTO roomPostDTO = new RoomPostDTO();
         roomPostDTO.setGameDifficulty(GameDifficulty.EASY);
         roomPostDTO.setGameLanguage(GameLanguage.PYTHON);
-        roomPostDTO.setGameMode(GameMode.RACE);
+        roomPostDTO.setGameMode(GameMode.SPRINT_ARCADE);
 
         Mockito.when(userService.getUserbyId(host.getId())).thenReturn(host);
         Mockito.when(roomRepository.save(Mockito.any(Room.class))).thenAnswer(invocation -> {
@@ -591,7 +591,7 @@ class RoomServiceTest {
         RoomPostDTO roomPostDTO = new RoomPostDTO();
         roomPostDTO.setGameDifficulty(GameDifficulty.EASY);
         roomPostDTO.setGameLanguage(GameLanguage.PYTHON);
-        roomPostDTO.setGameMode(GameMode.RACE);
+        roomPostDTO.setGameMode(GameMode.SPRINT_ARCADE);
 
         Mockito.when(userService.getUserbyId(host.getId())).thenReturn(host);
         Mockito.when(roomRepository.save(Mockito.any(Room.class))).thenAnswer(invocation -> {
@@ -628,7 +628,7 @@ class RoomServiceTest {
         RoomPostDTO roomPostDTO = new RoomPostDTO();
         roomPostDTO.setGameDifficulty(GameDifficulty.EASY);
         roomPostDTO.setGameLanguage(GameLanguage.PYTHON);
-        roomPostDTO.setGameMode(GameMode.RACE);
+        roomPostDTO.setGameMode(GameMode.SPRINT_ARCADE);
 
         Mockito.when(userService.getUserbyId(host.getId())).thenReturn(host);
         Mockito.when(roomRepository.save(Mockito.any(Room.class))).thenAnswer(invocation -> {


### PR DESCRIPTION
…ins reset after every round, coins only obtained in ARCADE, shop accessible only ARCADE, adapted all old tests to work with new changes, added new tests

constant/GameMode.java

Renamed both enum values. RACE became SPRINT_ARCADE (the full gamemode with coins and shop) and SPRINT became SPRINT_CLASSIC (no coins, no shop, no items).

service/CodeExecutionService.java — awardPoints()

Added a game mode check before awarding coins and total points. In Sprint Arcade, passing test cases still earns coins and
contributes to total points as before. In Sprint Classic, no coins are awarded but total points are awarded. 

service/GameService.java — purchaseSabotage()

Added an early rejection if the game is not Sprint Arcade. Any attempt to buy or use a sabotage item in Sprint Classic returns HTTP 403 FORBIDDEN immediately, before touching coins or the opponent.

service/GameService.java — endGameSession()

Added a coin reset loop at the end of every game. After updating win/loss statistics, all players' coin balances are set to zero. This applies to both modes: in Sprint Classic the balance is already zero, so it is a safe,